### PR TITLE
Feat/UI improvements

### DIFF
--- a/src/agent/display.rs
+++ b/src/agent/display.rs
@@ -4,8 +4,7 @@ use tinyharness_lib::{
     config::load_settings,
     provider::{Message, Role},
     token::{
-        ContextWindowSize, check_context_warning, estimate_conversation_tokens, estimate_tokens,
-        format_token_count,
+        ContextWindowSize, check_context_warning, estimate_conversation_tokens, format_token_count,
     },
 };
 
@@ -97,7 +96,11 @@ pub fn print_conversation_history<W: Write>(
                 }
                 if !msg.tool_calls.is_empty() {
                     for tc in &msg.tool_calls {
-                        writeln!(stdout, "{}  {}▶{} {}", DIM, CYAN, RESET, tc.function.name)?;
+                        writeln!(
+                            stdout,
+                            "{BG_DIM}  {DIM}▶ {WHITE}{name}{DIM}{FILL_EOL}{RESET}",
+                            name = tc.function.name
+                        )?;
                     }
                 }
                 writeln!(stdout)?;
@@ -108,19 +111,29 @@ pub fn print_conversation_history<W: Write>(
 
                 if tool_name == "read" {
                     let summary = result_body.lines().next().unwrap_or("(empty result)");
-                    writeln!(stdout, "    {}", summary)?;
+                    writeln!(
+                        stdout,
+                        "{BG_DIM}      {DIM}{summary}{FILL_EOL}{RESET}",
+                        summary = summary
+                    )?;
                 } else if matches!(tool_name, "ls" | "grep" | "glob") {
                     let summary = summarize_listing_result(result_body, tool_name);
-                    writeln!(stdout, "    {}", summary)?;
+                    writeln!(
+                        stdout,
+                        "{BG_DIM}      {DIM}{summary}{FILL_EOL}{RESET}",
+                        summary = summary
+                    )?;
                 } else {
                     crate::ui::wrap::write_wrapped_lines(
                         stdout,
                         result_body,
-                        "    ",
-                        "      ",
+                        &format!("{BG_DIM}      "),
+                        &format!("      {BG_DIM}{DIM}"),
                         crate::ui::wrap::MAX_LINE_WIDTH,
+                        true,
                     )?;
                 }
+                writeln!(stdout, "{RESET}")?;
             }
         }
     }
@@ -129,9 +142,53 @@ pub fn print_conversation_history<W: Write>(
     Ok(())
 }
 
-/// Display token usage after a turn is complete.
-pub fn display_token_usage<W: Write>(
+/// Format a compact context status line (pi-style).
+///
+/// Returns a string like: `5 msgs · 1.2K/8K (15%) · 2 pinned`
+/// Colors are applied based on usage thresholds.
+pub fn format_context_status(
+    msg_count: usize,
+    pinned_count: usize,
+    estimated_tokens: u32,
+    context_size: ContextWindowSize,
+) -> String {
+    let usage_pct = context_size.usage_percentage(estimated_tokens);
+    let used_str = format_token_count(estimated_tokens);
+    let max_str = format_token_count(context_size.tokens());
+
+    let pct_color = if usage_pct >= 90.0 {
+        RED
+    } else if usage_pct >= 70.0 {
+        YELLOW
+    } else {
+        GRAY
+    };
+
+    let mut parts = vec![format!("{} msgs", msg_count)];
+    parts.push(format!(
+        "{}{}/{}{} ({:.0}%){}",
+        pct_color, used_str, max_str, pct_color, usage_pct, RESET
+    ));
+    if pinned_count > 0 {
+        parts.push(format!("{}{} pinned{}", BLUE, pinned_count, RESET));
+    }
+
+    format!(
+        "{}{}{}",
+        DIM,
+        parts.join(&format!(" {}·{} ", DIM, RESET)),
+        RESET
+    )
+}
+
+/// Display a pi-style context status line.
+///
+/// Shows a compact dim line with message count,
+/// token usage, context percentage, and pinned file count.
+/// Also emits a warning if the context window is nearing capacity.
+pub fn display_context_status<W: Write>(
     messages: &[Message],
+    pinned_count: usize,
     token_usage: Option<&tinyharness_lib::provider::TokenUsage>,
     stdout: &mut W,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -142,48 +199,14 @@ pub fn display_token_usage<W: Write>(
         .context_limit
         .map(ContextWindowSize::Custom)
         .unwrap_or_else(ContextWindowSize::default_size);
-    let usage_pct = context_size.usage_percentage(estimated_total);
 
-    let is_estimated = token_usage.is_none();
-    let (prompt_tokens, completion_tokens, total_tokens) = if let Some(usage) = token_usage {
-        (
-            usage.prompt_tokens,
-            usage.completion_tokens,
-            usage.total_tokens,
-        )
-    } else {
-        let prompt_est =
-            estimate_conversation_tokens(&messages[..messages.len().saturating_sub(1)]);
-        let last_msg = messages.last().map(|m| m.content.as_str()).unwrap_or("");
-        let completion_est = estimate_tokens(last_msg);
-        (prompt_est, completion_est, prompt_est + completion_est)
-    };
+    // Update estimated total with actual usage if available
+    let estimated_total = token_usage
+        .map(|u| u.total_tokens)
+        .unwrap_or(estimated_total);
 
-    let estimation_marker = if is_estimated { " (estimated)" } else { "" };
-
-    writeln!(
-        stdout,
-        "\n{}{}Tokens{}{}:{} prompt={}, completion={}, total={} | {}{}{} of context ({:.1}%){}",
-        DIM,
-        BOLD,
-        if is_estimated { YELLOW } else { RESET },
-        estimation_marker,
-        RESET,
-        prompt_tokens,
-        completion_tokens,
-        total_tokens,
-        if usage_pct >= 90.0 {
-            RED
-        } else if usage_pct >= 70.0 {
-            YELLOW
-        } else {
-            GRAY
-        },
-        format_token_count(estimated_total),
-        RESET,
-        usage_pct,
-        RESET
-    )?;
+    let status = format_context_status(messages.len(), pinned_count, estimated_total, context_size);
+    writeln!(stdout, "{}", status)?;
 
     // Show context warning if needed
     if let Some(warning) = check_context_warning(estimated_total, context_size) {
@@ -205,7 +228,6 @@ pub fn display_token_usage<W: Write>(
         )?;
     }
 
-    stdout.write_all("\n".as_bytes())?;
     stdout.flush()?;
     Ok(())
 }
@@ -372,5 +394,41 @@ mod tests {
         let result = format_args_summary(&args);
         // Should not panic and should contain the truncation marker
         assert!(result.contains("content="));
+    }
+
+    #[test]
+    fn test_format_context_status_low_usage() {
+        // 500 tokens out of 8K = ~6%
+        let result = format_context_status(5, 0, 500, ContextWindowSize::Small8K);
+        // Should contain "5 msgs", token info, and percentage
+        assert!(result.contains("5 msgs"));
+        assert!(result.contains("500"));
+        assert!(result.contains("8.2K")); // 8192 tokens = 8.2K
+        assert!(result.contains("6%"));
+        // No pinned info when count is 0
+        assert!(!result.contains("pinned"));
+    }
+
+    #[test]
+    fn test_format_context_status_with_pinned() {
+        let result = format_context_status(10, 3, 2000, ContextWindowSize::Small8K);
+        assert!(result.contains("10 msgs"));
+        assert!(result.contains("3 pinned"));
+        assert!(result.contains("2.0K/8.2K")); // 2000 = 2.0K, 8192 = 8.2K
+    }
+
+    #[test]
+    fn test_format_context_status_high_usage_warning_color() {
+        // 90%+ should use RED color code
+        let result = format_context_status(20, 0, 7500, ContextWindowSize::Small8K);
+        assert!(result.contains("20 msgs"));
+        assert!(result.contains(RED));
+    }
+
+    #[test]
+    fn test_format_context_status_medium_usage_warning_color() {
+        // 70-89% should use YELLOW color code
+        let result = format_context_status(10, 0, 6000, ContextWindowSize::Small8K);
+        assert!(result.contains(YELLOW));
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -129,9 +129,14 @@ pub async fn run_agent_loop(
             estimate_conversation_tokens(messages),
             context_size,
         );
+
+        // Include session name in prompt if available
+        let session_name = session.meta().name.as_deref().unwrap_or("unnamed");
+        let session_suffix = format!(" {DIM}({}){RESET}", session_name);
+
         let prompt = format!(
-            "{}\n{}[{}]{}> {}{}",
-            status_line, mode_color, mode_label, RESET, BLUE, RESET
+            "{}{}{}\n{}[{}]{}> {}{}",
+            status_line, session_suffix, RESET, mode_color, mode_label, RESET, BLUE, RESET
         );
         let continuation_prompt = format!(
             "{}[{}]{}...> {}{}",
@@ -294,6 +299,11 @@ pub async fn run_agent_loop(
             let mut is_error = false;
             let mut was_interrupted = false;
 
+            // Spinner state: animate while waiting for the first content chunk
+            let mut spinner_idx: usize = 0;
+            let mut waiting_for_first_chunk = true;
+            let mut has_shown_spinner = false;
+
             stdout.write_all(ORANGE.as_bytes())?;
 
             loop {
@@ -314,6 +324,16 @@ pub async fn run_agent_loop(
                                 }
 
                                 if !msg.message.content.is_empty() {
+                                    // Clear spinner before first content
+                                    if waiting_for_first_chunk && has_shown_spinner {
+                                        // Erase the spinner line: move to start, clear line
+                                        write!(stdout, "\r{CLEAR_LINE}")?;
+                                        stdout.flush()?;
+                                        waiting_for_first_chunk = false;
+                                    } else {
+                                        waiting_for_first_chunk = false;
+                                    }
+
                                     response_content.push_str(&msg.message.content);
                                     stdout.write_all(msg.message.content.as_bytes())?;
                                     stdout.flush()?;
@@ -335,8 +355,27 @@ pub async fn run_agent_loop(
                             was_interrupted = true;
                             break;
                         }
+
+                        // Show spinner animation while waiting for first chunk
+                        if waiting_for_first_chunk {
+                            let frame = SPINNER_FRAMES[spinner_idx % SPINNER_FRAMES.len()];
+                            spinner_idx += 1;
+                            if has_shown_spinner {
+                                write!(stdout, "\r{DIM}{frame} Thinking...{RESET}")?;
+                            } else {
+                                write!(stdout, "{DIM}{frame} Thinking...{RESET}")?;
+                                has_shown_spinner = true;
+                            }
+                            stdout.flush()?;
+                        }
                     }
                 }
+            }
+
+            // Clear spinner if still showing when stream ends
+            if waiting_for_first_chunk && has_shown_spinner {
+                write!(stdout, "\r{CLEAR_LINE}")?;
+                stdout.flush()?;
             }
 
             // Handle user interrupt (Ctrl+C during generation)

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -18,6 +18,7 @@ use tokio::sync::Mutex;
 
 use tinyharness_lib::{
     config::load_settings,
+    mode::AgentMode,
     provider::{Message, Provider, Role},
     session::{Session, SessionStore},
     token::{ContextWindowSize, estimate_conversation_tokens},
@@ -115,6 +116,12 @@ pub async fn run_agent_loop(
         interrupted.store(false, Ordering::SeqCst);
 
         let mode_label = dispatcher.current_mode.to_string();
+        let mode_color = match dispatcher.current_mode {
+            AgentMode::Casual => GREEN,
+            AgentMode::Planning => YELLOW,
+            AgentMode::Agent => CYAN,
+            AgentMode::Research => ORANGE,
+        };
         let pinned_count = dispatcher.file_context.pinned_file_count();
         let status_line = display::format_context_status(
             messages.len(),
@@ -124,10 +131,12 @@ pub async fn run_agent_loop(
         );
         let prompt = format!(
             "{}\n{}[{}]{}> {}{}",
-            status_line, BOLD, mode_label, RESET, BLUE, RESET
+            status_line, mode_color, mode_label, RESET, BLUE, RESET
         );
-        let continuation_prompt =
-            format!("{}[{}]{}...> {}{}", BOLD, mode_label, RESET, BLUE, RESET);
+        let continuation_prompt = format!(
+            "{}[{}]{}...> {}{}",
+            mode_color, mode_label, RESET, BLUE, RESET
+        );
 
         // Read input with support for multi-line continuation
         let user_input = read_multiline_input(

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -17,8 +17,10 @@ use rustyline::Editor;
 use tokio::sync::Mutex;
 
 use tinyharness_lib::{
+    config::load_settings,
     provider::{Message, Provider, Role},
     session::{Session, SessionStore},
+    token::{ContextWindowSize, estimate_conversation_tokens},
     tools::ToolManager,
 };
 
@@ -29,8 +31,8 @@ use crate::{
 };
 
 pub use display::{
-    format_args_summary, print_context_load_warning, print_conversation_history,
-    summarize_listing_result,
+    format_args_summary, format_context_status, print_context_load_warning,
+    print_conversation_history, summarize_listing_result,
 };
 pub use input::read_multiline_input;
 pub use safety::{is_safe_command, strip_safe_descriptor_redirections};
@@ -80,7 +82,7 @@ pub async fn run_agent_loop(
         print_conversation_history(messages, &mut stdout)?;
     }
 
-    // Warn if the loaded session is near or over the context window limit.
+    // Warn if near/over the context window limit.
     print_context_load_warning(messages, &mut stdout)?;
 
     let helper = CommandHelper::new();
@@ -102,26 +104,30 @@ pub async fn run_agent_loop(
         rustyline::EventHandler::Simple(rustyline::Cmd::Newline),
     );
 
+    let settings = load_settings();
+    let context_size = settings
+        .context_limit
+        .map(ContextWindowSize::Custom)
+        .unwrap_or_else(ContextWindowSize::default_size);
+
     loop {
         // Clear any stale interrupt flag from a previous turn.
         interrupted.store(false, Ordering::SeqCst);
 
         let mode_label = dispatcher.current_mode.to_string();
-        let msg_count = messages.len();
         let pinned_count = dispatcher.file_context.pinned_file_count();
-        let context_info = if pinned_count > 0 {
-            format!("{} msgs,{}{}{} pinned", msg_count, BLUE, pinned_count, GRAY)
-        } else {
-            format!("{} msgs", msg_count)
-        };
+        let status_line = display::format_context_status(
+            messages.len(),
+            pinned_count,
+            estimate_conversation_tokens(messages),
+            context_size,
+        );
         let prompt = format!(
-            "{}[{}]{} {}{}> {}{}",
-            BOLD, mode_label, RESET, GRAY, context_info, BLUE, RESET
+            "{}\n{}[{}]{}> {}{}",
+            status_line, BOLD, mode_label, RESET, BLUE, RESET
         );
-        let continuation_prompt = format!(
-            "{}[{}]{} {}{}...> {}{}",
-            BOLD, mode_label, RESET, GRAY, context_info, BLUE, RESET
-        );
+        let continuation_prompt =
+            format!("{}[{}]{}...> {}{}", BOLD, mode_label, RESET, BLUE, RESET);
 
         // Read input with support for multi-line continuation
         let user_input = read_multiline_input(
@@ -249,7 +255,6 @@ pub async fn run_agent_loop(
 
         // auto_accept persists across all agent iterations within this user turn,
         let mut auto_accept = false;
-        let mut token_usage: Option<tinyharness_lib::provider::TokenUsage> = None;
 
         loop {
             // Filter tools based on current mode
@@ -297,11 +302,6 @@ pub async fn run_agent_loop(
 
                                 if msg.is_error {
                                     is_error = true;
-                                }
-
-                                // Capture token usage from the final response
-                                if msg.done && token_usage.is_none() {
-                                    token_usage = msg.usage.clone();
                                 }
 
                                 if !msg.message.content.is_empty() {
@@ -429,8 +429,8 @@ pub async fn run_agent_loop(
             break;
         }
 
-        // Display token usage after turn is complete
-        display::display_token_usage(messages, token_usage.as_ref(), &mut stdout)?;
+        // Blank line after agent response for visual separation
+        writeln!(stdout)?;
     }
 
     // Save history on exit

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -134,13 +134,28 @@ pub async fn run_agent_loop(
         let session_name = session.meta().name.as_deref().unwrap_or("unnamed");
         let session_suffix = format!(" {DIM}({}){RESET}", session_name);
 
+        // Include current model name next to the mode label
+        let model_name = {
+            let p = provider.lock().await;
+            p.current_model().unwrap_or_else(|| "?".to_string())
+        };
+        let model_suffix = format!(" {DIM}{}{RESET}", model_name);
+
         let prompt = format!(
-            "{}{}{}\n{}[{}]{}> {}{}",
-            status_line, session_suffix, RESET, mode_color, mode_label, RESET, BLUE, RESET
+            "{}{}{}\n{}[{}]{}{}> {}{}",
+            status_line,
+            session_suffix,
+            RESET,
+            mode_color,
+            mode_label,
+            RESET,
+            model_suffix,
+            BLUE,
+            RESET
         );
         let continuation_prompt = format!(
-            "{}[{}]{}...> {}{}",
-            mode_color, mode_label, RESET, BLUE, RESET
+            "{}[{}]{}{}...> {}{}",
+            mode_color, mode_label, RESET, model_suffix, BLUE, RESET
         );
 
         // Read input with support for multi-line continuation

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -230,6 +230,7 @@ async fn execute_generic_tool<W: Write>(
     stdout: &mut W,
     auto_accepted: bool,
 ) {
+    // Show the "Executing..." header line
     if auto_accepted {
         if call.function.name == "run" {
             if let Some(cmd) = call
@@ -276,12 +277,41 @@ async fn execute_generic_tool<W: Write>(
     }
     stdout.flush().unwrap();
 
+    // Spinner state for tool execution animation
+    let mut spinner_idx: usize = 0;
+    let mut has_shown_spinner = false;
+
     // Capture start time for duration tracking
     let start_time = std::time::Instant::now();
 
-    let result = tool_manager
-        .execute_tool_call(&call.function.name, &call.function.arguments)
-        .await;
+    // Execute tool call with spinner animation using tokio::pin! and select!
+    let tool_fut = tool_manager.execute_tool_call(&call.function.name, &call.function.arguments);
+    tokio::pin!(tool_fut);
+
+    let result = loop {
+        tokio::select! {
+            result = &mut tool_fut => {
+                // Tool finished — clear spinner line if we showed one
+                if has_shown_spinner {
+                    write!(stdout, "\r{CLEAR_LINE}{RESET}").unwrap();
+                    stdout.flush().unwrap();
+                }
+                break result;
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(80)) => {
+                // Animate spinner
+                let frame = SPINNER_FRAMES[spinner_idx % SPINNER_FRAMES.len()];
+                spinner_idx += 1;
+                if has_shown_spinner {
+                    write!(stdout, "\r{DIM}{frame} {RESET}").unwrap();
+                } else {
+                    write!(stdout, "{DIM}{frame} {RESET}").unwrap();
+                    has_shown_spinner = true;
+                }
+                stdout.flush().unwrap();
+            }
+        }
+    };
 
     let duration_ms = start_time.elapsed().as_millis() as u64;
 
@@ -307,80 +337,87 @@ async fn execute_generic_tool<W: Write>(
     // For tools that return potentially large listings, show only a summary
     match call.function.name.as_str() {
         "read" => {
+            let is_error = result.starts_with("Error:");
             let summary = result.lines().next().unwrap_or("(empty result)");
-            let indicator = if result.starts_with("Error:") {
-                RED
-            } else {
-                GREEN
-            };
-            let icon = if result.starts_with("Error:") {
-                "✗"
-            } else {
-                "✓"
-            };
+            let indicator = if is_error { RED } else { GREEN };
+            let icon = if is_error { "✗" } else { "✓" };
+            let summary_color = if is_error { RED } else { DIM };
             writeln!(
                 stdout,
-                "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}{DIM}{summary}{FILL_EOL}{RESET}",
+                "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}{summary_color}{summary}{FILL_EOL}{RESET}",
                 indicator = indicator,
                 icon = icon,
                 name = call.function.name,
                 duration = format_duration(duration_ms),
+                summary_color = summary_color,
                 summary = summary
             )
             .unwrap();
         }
         "ls" | "grep" | "glob" => {
+            let is_error = result.starts_with("Error:");
             let summary = super::display::summarize_listing_result(&result, &call.function.name);
-            let indicator = if result.starts_with("Error:") {
-                RED
-            } else {
-                GREEN
-            };
-            let icon = if result.starts_with("Error:") {
-                "✗"
-            } else {
-                "✓"
-            };
+            let indicator = if is_error { RED } else { GREEN };
+            let icon = if is_error { "✗" } else { "✓" };
+            let summary_color = if is_error { RED } else { DIM };
             writeln!(
                 stdout,
-                "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}{DIM}{summary}{FILL_EOL}{RESET}",
+                "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}{summary_color}{summary}{FILL_EOL}{RESET}",
                 indicator = indicator,
                 icon = icon,
                 name = call.function.name,
                 duration = format_duration(duration_ms),
+                summary_color = summary_color,
                 summary = summary
             )
             .unwrap();
         }
         _ => {
-            let indicator = if result.starts_with("Error:") {
-                RED
+            let is_error = result.starts_with("Error:");
+            let indicator = if is_error { RED } else { GREEN };
+            let icon = if is_error { "✗" } else { "✓" };
+
+            if is_error {
+                // Compact single-line error: truncate to fit one line
+                let error_msg = result.lines().next().unwrap_or("Error");
+                // Truncate at 80 chars to keep the line compact
+                let max_err_len = 80;
+                let truncated = if error_msg.len() > max_err_len {
+                    let cut = error_msg.floor_char_boundary(max_err_len - 1);
+                    format!("{}…", &error_msg[..cut])
+                } else {
+                    error_msg.to_string()
+                };
+                writeln!(
+                    stdout,
+                    "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}{RED}{truncated}{FILL_EOL}{RESET}",
+                    indicator = indicator,
+                    icon = icon,
+                    name = call.function.name,
+                    duration = format_duration(duration_ms),
+                    truncated = truncated,
+                )
+                .unwrap();
             } else {
-                GREEN
-            };
-            let icon = if result.starts_with("Error:") {
-                "✗"
-            } else {
-                "✓"
-            };
-            writeln!(
-                stdout,
-                "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}",
-                indicator = indicator,
-                icon = icon,
-                name = call.function.name,
-                duration = format_duration(duration_ms),
-            )
-            .unwrap();
-            crate::ui::wrap::write_wrapped_lines(
-                stdout,
-                &result,
-                &format!("{BG_DIM}      "),
-                &format!("      {BG_DIM}{DIM}"),
-                crate::ui::wrap::MAX_LINE_WIDTH,
-                true, // fill background to end of line
-            )
-            .unwrap();
+                writeln!(
+                    stdout,
+                    "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}",
+                    indicator = indicator,
+                    icon = icon,
+                    name = call.function.name,
+                    duration = format_duration(duration_ms),
+                )
+                .unwrap();
+                crate::ui::wrap::write_wrapped_lines(
+                    stdout,
+                    &result,
+                    &format!("{BG_DIM}      "),
+                    &format!("      {BG_DIM}{DIM}"),
+                    crate::ui::wrap::MAX_LINE_WIDTH,
+                    true, // fill background to end of line
+                )
+                .unwrap();
+            }
         }
     }
     writeln!(stdout, "{RESET}").unwrap();

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -39,7 +39,11 @@ pub async fn handle_tool_calls<W: Write>(
     }
 
     let tool_count = tool_calls.len();
-    writeln!(stdout, "\n{}  {} tool call(s){}", DIM, tool_count, RESET)?;
+    writeln!(
+        stdout,
+        "\n{BG_TOOL}  {WHITE}{count} tool call(s){FILL_EOL}{RESET}",
+        count = tool_count
+    )?;
 
     messages.push(Message {
         role: Role::Assistant,
@@ -222,37 +226,39 @@ async fn execute_generic_tool<W: Write>(
             {
                 writeln!(
                     stdout,
-                    "  {}▶ {}{} (auto-accepted){}",
-                    DIM, call.function.name, RESET, RESET
+                    "{BG_DIM}  {DIM}▶ {WHITE}{name}{DIM} (auto-accepted){FILL_EOL}{RESET}",
+                    name = call.function.name
                 )
                 .unwrap();
-                writeln!(stdout, "    {}{}{}", CYAN, cmd, RESET).unwrap();
+                writeln!(
+                    stdout,
+                    "{BG_DIM}      {BRIGHT_CYAN}{cmd}{FILL_EOL}{RESET}",
+                    cmd = cmd
+                )
+                .unwrap();
             } else {
                 writeln!(
                     stdout,
-                    "  {}▶ {}{} (auto-accepted){}",
-                    DIM, call.function.name, RESET, RESET
+                    "{BG_DIM}  {DIM}▶ {WHITE}{name}{DIM} (auto-accepted){FILL_EOL}{RESET}",
+                    name = call.function.name
                 )
                 .unwrap();
             }
         } else {
             writeln!(
                 stdout,
-                "  {}▶ {}{} (auto-accepted){}",
-                DIM, call.function.name, RESET, RESET
+                "{BG_DIM}  {DIM}▶ {WHITE}{name}{DIM} (auto-accepted){FILL_EOL}{RESET}",
+                name = call.function.name
             )
             .unwrap();
         }
     } else {
-        stdout
-            .write_all(
-                format!(
-                    "  {}▶ {}{} Executing {}...\n",
-                    CYAN, RESET, call.function.name, RESET
-                )
-                .as_bytes(),
-            )
-            .unwrap();
+        writeln!(
+            stdout,
+            "{BG_DIM}  {DIM}▶ {WHITE}{name}{DIM} Executing...{FILL_EOL}{RESET}",
+            name = call.function.name
+        )
+        .unwrap();
     }
     stdout.flush().unwrap();
 
@@ -288,23 +294,35 @@ async fn execute_generic_tool<W: Write>(
     match call.function.name.as_str() {
         "read" => {
             let summary = result.lines().next().unwrap_or("(empty result)");
-            writeln!(stdout, "    {}", summary).unwrap();
+            writeln!(
+                stdout,
+                "{BG_DIM}      {DIM}{summary}{FILL_EOL}{RESET}",
+                summary = summary
+            )
+            .unwrap();
         }
         "ls" | "grep" | "glob" => {
             let summary = super::display::summarize_listing_result(&result, &call.function.name);
-            writeln!(stdout, "    {}", summary).unwrap();
+            writeln!(
+                stdout,
+                "{BG_DIM}      {DIM}{summary}{FILL_EOL}{RESET}",
+                summary = summary
+            )
+            .unwrap();
         }
         _ => {
             crate::ui::wrap::write_wrapped_lines(
                 stdout,
                 &result,
-                "    ",
-                "      ",
+                &format!("{BG_DIM}      "),
+                &format!("      {BG_DIM}{DIM}"),
                 crate::ui::wrap::MAX_LINE_WIDTH,
+                true, // fill background to end of line
             )
             .unwrap();
         }
     }
+    writeln!(stdout, "{RESET}").unwrap();
     stdout.flush().unwrap();
     messages.push(Message {
         role: Role::Tool,

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -208,6 +208,20 @@ fn confirm_tool_call<W: Write>(
 
 /// Execute a generic tool call, display the result summary, and record the
 /// tool result as a message in the conversation.
+/// Format a duration in milliseconds as a human-readable string.
+/// Under 1 second: "42ms", 1-59 seconds: "1.2s", 60+ seconds: "1m 23s"
+fn format_duration(ms: u64) -> String {
+    if ms < 1000 {
+        format!("{}ms ", ms)
+    } else if ms < 60_000 {
+        format!("{:.1}s ", ms as f64 / 1000.0)
+    } else {
+        let mins = ms / 60_000;
+        let secs = (ms % 60_000) / 1000;
+        format!("{}m {}s ", mins, secs)
+    }
+}
+
 async fn execute_generic_tool<W: Write>(
     call: &ToolCall,
     tool_manager: &ToolManager,
@@ -294,23 +308,70 @@ async fn execute_generic_tool<W: Write>(
     match call.function.name.as_str() {
         "read" => {
             let summary = result.lines().next().unwrap_or("(empty result)");
+            let indicator = if result.starts_with("Error:") {
+                RED
+            } else {
+                GREEN
+            };
+            let icon = if result.starts_with("Error:") {
+                "✗"
+            } else {
+                "✓"
+            };
             writeln!(
                 stdout,
-                "{BG_DIM}      {DIM}{summary}{FILL_EOL}{RESET}",
+                "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}{DIM}{summary}{FILL_EOL}{RESET}",
+                indicator = indicator,
+                icon = icon,
+                name = call.function.name,
+                duration = format_duration(duration_ms),
                 summary = summary
             )
             .unwrap();
         }
         "ls" | "grep" | "glob" => {
             let summary = super::display::summarize_listing_result(&result, &call.function.name);
+            let indicator = if result.starts_with("Error:") {
+                RED
+            } else {
+                GREEN
+            };
+            let icon = if result.starts_with("Error:") {
+                "✗"
+            } else {
+                "✓"
+            };
             writeln!(
                 stdout,
-                "{BG_DIM}      {DIM}{summary}{FILL_EOL}{RESET}",
+                "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}{DIM}{summary}{FILL_EOL}{RESET}",
+                indicator = indicator,
+                icon = icon,
+                name = call.function.name,
+                duration = format_duration(duration_ms),
                 summary = summary
             )
             .unwrap();
         }
         _ => {
+            let indicator = if result.starts_with("Error:") {
+                RED
+            } else {
+                GREEN
+            };
+            let icon = if result.starts_with("Error:") {
+                "✗"
+            } else {
+                "✓"
+            };
+            writeln!(
+                stdout,
+                "{BG_DIM}  {indicator}{icon}{RESET}{BG_DIM} {DIM}{name}{RESET}{BG_DIM} {duration}",
+                indicator = indicator,
+                icon = icon,
+                name = call.function.name,
+                duration = format_duration(duration_ms),
+            )
+            .unwrap();
             crate::ui::wrap::write_wrapped_lines(
                 stdout,
                 &result,

--- a/src/style.rs
+++ b/src/style.rs
@@ -38,3 +38,9 @@ pub const ACCENT_COLOR: &str = MAGENTA; // For highlights and emphasis
 
 // Special escape sequences
 pub const CLEAR_SCREEN: &str = "\x1b[2J\x1b[H";
+
+/// Spinner frames for the progress indicator (Braille patterns)
+pub const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Clear the entire current line (used by spinner to erase previous frame)
+pub const CLEAR_LINE: &str = "\x1b[2K";

--- a/src/style.rs
+++ b/src/style.rs
@@ -14,10 +14,21 @@ pub const YELLOW: &str = "\x1b[33m";
 pub const BLUE: &str = "\x1b[34m";
 pub const MAGENTA: &str = "\x1b[35m";
 pub const CYAN: &str = "\x1b[36m";
+pub const WHITE: &str = "\x1b[37m";
 
 // Bright / extended colors
 pub const GRAY: &str = "\x1b[90m";
 pub const ORANGE: &str = "\x1b[38;5;208m";
+pub const BRIGHT_YELLOW: &str = "\x1b[93m";
+pub const BRIGHT_CYAN: &str = "\x1b[96m";
+
+// Background colors (subtle, for tool call highlighting)
+pub const BG_DIM: &str = "\x1b[48;5;236m"; // Dark gray bg — tool call results
+pub const BG_TOOL: &str = "\x1b[48;5;237m"; // Slightly lighter gray bg — tool headers
+pub const BG_WARN: &str = "\x1b[48;5;17m"; // Dark navy bg — confirmation/warning headers
+
+// Line fill: clears from cursor to end of line, filling with current background color
+pub const FILL_EOL: &str = "\x1b[K";
 
 // UI styling presets
 pub const TITLE_COLOR: &str = CYAN; // For titles and headers

--- a/src/ui/confirm.rs
+++ b/src/ui/confirm.rs
@@ -10,11 +10,11 @@ use tinyharness_lib::provider::ToolCall;
 use crate::style::*;
 
 /// Maximum width available for the command text on the first line,
-/// after the `  ` prefix (2 chars) and `$ ` (2 chars).
-const CMD_FIRST_AVAIL: usize = MAX_LINE_WIDTH - 4;
+/// after the `    ` prefix (4 chars) and `$ ` (2 chars).
+const CMD_FIRST_AVAIL: usize = MAX_LINE_WIDTH - 6;
 /// Maximum width available for continuation lines,
-/// after the `  ` prefix (2 chars) and `> ` (2 chars).
-const CMD_CONT_AVAIL: usize = MAX_LINE_WIDTH - 4;
+/// after the `    ` prefix (4 chars) and `> ` (2 chars).
+const CMD_CONT_AVAIL: usize = MAX_LINE_WIDTH - 6;
 
 /// Display a shell command, splitting it across multiple lines at word
 /// boundaries when it exceeds the available terminal width.
@@ -22,8 +22,8 @@ const CMD_CONT_AVAIL: usize = MAX_LINE_WIDTH - 4;
 /// Each line has BG_WARN background filling the full terminal width.
 fn write_command_lines<W: Write>(stdout: &mut W, cmd: &str) -> Result<(), Box<dyn Error>> {
     // BG_WARN starts at column 0, no RESET until end of line.
-    let prefix_first = format!("{BG_WARN}  {BOLD}{WHITE}$ ");
-    let prefix_cont = format!("{BG_WARN}  {DIM}{WHITE}> ");
+    let prefix_first = format!("{BG_WARN}    {BOLD}{WHITE}$ ");
+    let prefix_cont = format!("{BG_WARN}    {DIM}>{WHITE} ");
 
     // Split at spaces for word-wrapping
     let mut remaining = cmd;

--- a/src/ui/confirm.rs
+++ b/src/ui/confirm.rs
@@ -10,20 +10,20 @@ use tinyharness_lib::provider::ToolCall;
 use crate::style::*;
 
 /// Maximum width available for the command text on the first line,
-/// after the `  │ ` prefix (4 chars) and `$ ` (2 chars).
-const CMD_FIRST_AVAIL: usize = MAX_LINE_WIDTH - 6;
+/// after the `  ` prefix (2 chars) and `$ ` (2 chars).
+const CMD_FIRST_AVAIL: usize = MAX_LINE_WIDTH - 4;
 /// Maximum width available for continuation lines,
-/// after the `  │ > ` prefix (6 chars).
-const CMD_CONT_AVAIL: usize = MAX_LINE_WIDTH - 6;
+/// after the `  ` prefix (2 chars) and `> ` (2 chars).
+const CMD_CONT_AVAIL: usize = MAX_LINE_WIDTH - 4;
 
 /// Display a shell command, splitting it across multiple lines at word
 /// boundaries when it exceeds the available terminal width.
 ///
-/// First line: `  │ $ cmd...`
-/// Continuation: `  │ > rest...`
+/// Each line has BG_WARN background filling the full terminal width.
 fn write_command_lines<W: Write>(stdout: &mut W, cmd: &str) -> Result<(), Box<dyn Error>> {
-    let prefix_first = format!("  │ {}{}$ {}", BOLD, TITLE_COLOR, RESET);
-    let prefix_cont = format!("  │ {}> {}{}", DIM, TITLE_COLOR, RESET);
+    // BG_WARN starts at column 0, no RESET until end of line.
+    let prefix_first = format!("{BG_WARN}  {BOLD}{WHITE}$ ");
+    let prefix_cont = format!("{BG_WARN}  {DIM}{WHITE}> ");
 
     // Split at spaces for word-wrapping
     let mut remaining = cmd;
@@ -37,7 +37,11 @@ fn write_command_lines<W: Write>(stdout: &mut W, cmd: &str) -> Result<(), Box<dy
         };
 
         if remaining.len() <= avail {
-            writeln!(stdout, "{}{}{}{}{}", prefix, CYAN, remaining, BOLD, RESET)?;
+            writeln!(
+                stdout,
+                "{prefix}{BRIGHT_CYAN}{remaining}{FILL_EOL}{RESET}",
+                remaining = remaining
+            )?;
             break;
         }
 
@@ -50,12 +54,8 @@ fn write_command_lines<W: Write>(stdout: &mut W, cmd: &str) -> Result<(), Box<dy
                 // No space found — hard-break at width limit
                 writeln!(
                     stdout,
-                    "{}{}{}{}{}",
-                    prefix,
-                    CYAN,
-                    &remaining[..chunk_end],
-                    BOLD,
-                    RESET
+                    "{prefix}{BRIGHT_CYAN}{chunk}{FILL_EOL}{RESET}",
+                    chunk = &remaining[..chunk_end]
                 )?;
                 remaining = remaining[chunk_end..].trim_start();
                 continue;
@@ -63,12 +63,8 @@ fn write_command_lines<W: Write>(stdout: &mut W, cmd: &str) -> Result<(), Box<dy
         };
         writeln!(
             stdout,
-            "{}{}{}{}{}",
-            prefix,
-            CYAN,
-            &chunk[..split_at],
-            BOLD,
-            RESET
+            "{prefix}{BRIGHT_CYAN}{chunk}{FILL_EOL}{RESET}",
+            chunk = &chunk[..split_at]
         )?;
         remaining = remaining[chunk[..split_at].len()..].trim_start();
     }
@@ -99,8 +95,8 @@ pub fn prompt_tool_confirmation<W: Write>(
     // ── Header ──
     writeln!(
         stdout,
-        "\n{}  ┌{}─── {}⚠ {}{}{} ───{}",
-        BOLD, BOX_COLOR, WARNING_COLOR, name, BOLD, BOX_COLOR, RESET
+        "\n{BG_WARN}  {WHITE}─── {BRIGHT_YELLOW}⚠ {WHITE}{name}{WHITE} ───{FILL_EOL}{RESET}",
+        name = name
     )?;
 
     // ── Arguments (skip large fields already shown in diff/preview) ──
@@ -126,7 +122,12 @@ pub fn prompt_tool_confirmation<W: Write>(
                 }
                 other => other.to_string(),
             };
-            writeln!(stdout, "  │ {}{}:{} {}", CYAN, key, RESET, val_str)?;
+            writeln!(
+                stdout,
+                "{BG_WARN}  {BRIGHT_CYAN}{key}: {WHITE}{val}{FILL_EOL}{RESET}",
+                key = key,
+                val = val_str
+            )?;
         }
     }
 
@@ -164,14 +165,9 @@ pub fn prompt_tool_confirmation<W: Write>(
     // ── Footer with prompt ──
     writeln!(
         stdout,
-        "  └{}───────────────────────────────{}",
-        BOX_COLOR, RESET
+        "{BG_WARN}  {DIM}───────────────────────────────{FILL_EOL}{RESET}"
     )?;
-    write!(
-        stdout,
-        "  {}Allow? {}y{}/n/a{}: {}",
-        BOLD, GREEN, BOLD, RESET, RESET
-    )?;
+    write!(stdout, "  {BOLD}Allow? {GREEN}y{BOLD}/n/a{RESET}: ")?;
     stdout.flush()?;
 
     let mut input = String::new();
@@ -193,7 +189,8 @@ mod tests {
 
     /// Strip ANSI escape sequences from a string for easier assertions.
     fn strip_ansi(s: &str) -> String {
-        let re = regex::Regex::new(r"\x1b\[[0-9;]*m").unwrap();
+        // Match SGR sequences (\x1b[...m) and other CSI sequences like \x1b[K (clear to EOL)
+        let re = regex::Regex::new(r"\x1b\[[0-9;]*[mK]").unwrap();
         re.replace_all(s, "").to_string()
     }
 
@@ -214,7 +211,7 @@ mod tests {
 
     #[test]
     fn test_long_command_wraps() {
-        // Build a command that exceeds MAX_LINE_WIDTH - 6 chars
+        // Build a command that exceeds MAX_LINE_WIDTH - 4 chars
         let long_cmd: Vec<String> = (0..50).map(|i| format!("arg{i}")).collect();
         let cmd = long_cmd.join(" ");
         assert!(

--- a/src/ui/diff.rs
+++ b/src/ui/diff.rs
@@ -2,6 +2,242 @@ use std::{error::Error, io::Write};
 
 use crate::style::*;
 
+// ── Diff computation (LCS-based algorithm) ─────────────────────────────────
+
+/// A single line in a diff hunk — either kept, removed, or added.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DiffLine<'a> {
+    /// Line present in both old and new (unchanged).
+    Keep(&'a str),
+    /// Line present only in old (removed).
+    Remove(&'a str),
+    /// Line present only in new (added).
+    Add(&'a str),
+}
+
+/// Compute the shortest edit script between `old` and `new`.
+///
+/// Uses a standard LCS (Longest Common Subsequence) dynamic programming approach
+/// to find the optimal alignment, then walks the DP table to produce the diff.
+/// This produces the same quality of diff as `git diff` for line-level changes.
+pub fn compute_diff<'a>(old: &'a [&str], new: &'a [&str]) -> Vec<DiffLine<'a>> {
+    let n = old.len();
+    let m = new.len();
+
+    // Trivial cases
+    if n == 0 && m == 0 {
+        return vec![];
+    }
+    if n == 0 {
+        return new.iter().map(|l| DiffLine::Add(l)).collect();
+    }
+    if m == 0 {
+        return old.iter().map(|l| DiffLine::Remove(l)).collect();
+    }
+    if old == new {
+        return old.iter().map(|l| DiffLine::Keep(l)).collect();
+    }
+
+    // Build LCS length table using O(n) space (rolling rows).
+    // dp[j] = LCS length for old[0..i] and new[0..j]
+    let mut dp = vec![0usize; m + 1];
+    let mut prev = vec![0usize; m + 1];
+
+    // We also need to store the full table for backtracking.
+    // For correctness we store the full (n+1) x (m+1) table.
+    // This is fine since diffs are typically small (file previews in confirmation prompts).
+    let mut table = vec![vec![0usize; m + 1]; n + 1];
+
+    for i in 1..=n {
+        prev.copy_from_slice(&dp);
+        for j in 1..=m {
+            if old[i - 1] == new[j - 1] {
+                dp[j] = prev[j - 1] + 1;
+            } else {
+                dp[j] = dp[j - 1].max(prev[j]);
+            }
+        }
+        table[i].copy_from_slice(&dp);
+    }
+
+    // Backtrack through the full table to reconstruct the diff
+    let mut result = Vec::with_capacity(n + m);
+    let mut i = n;
+    let mut j = m;
+
+    while i > 0 || j > 0 {
+        if i > 0 && j > 0 && old[i - 1] == new[j - 1] {
+            result.push(DiffLine::Keep(old[i - 1]));
+            i -= 1;
+            j -= 1;
+        } else if j > 0 && (i == 0 || table[i][j - 1] >= table[i - 1][j]) {
+            result.push(DiffLine::Add(new[j - 1]));
+            j -= 1;
+        } else {
+            result.push(DiffLine::Remove(old[i - 1]));
+            i -= 1;
+        }
+    }
+
+    result.reverse();
+    result
+}
+
+/// Context lines to show around each change in unified diff output.
+const DIFF_CONTEXT_LINES: usize = 3;
+
+/// Render a [`DiffLine`] sequence into unified-diff-style output with line
+/// numbers, `+`/`-`/` ` prefixes, and configurable context around changes.
+#[allow(unused_assignments)]
+fn render_diff_lines<W: Write>(
+    stdout: &mut W,
+    diff: &[DiffLine],
+    old_lines: &[&str],
+    new_lines: &[&str],
+    show_line_numbers: bool,
+) -> Result<(), Box<dyn Error>> {
+    if diff.is_empty() {
+        return Ok(());
+    }
+
+    // Compute line number width
+    let max_line = old_lines.len().max(new_lines.len()).max(1);
+    let num_width = if show_line_numbers {
+        max_line.to_string().len().max(2)
+    } else {
+        0
+    };
+
+    // Find hunks: groups of changes with context around them.
+    let change_indices: Vec<usize> = diff
+        .iter()
+        .enumerate()
+        .filter_map(|(i, l)| matches!(l, DiffLine::Remove(_) | DiffLine::Add(_)).then_some(i))
+        .collect();
+
+    if change_indices.is_empty() {
+        return Ok(());
+    }
+
+    // Merge overlapping/adjacent hunks
+    let mut hunk_ranges: Vec<(usize, usize)> = Vec::new();
+    let mut hunk_start = change_indices[0].saturating_sub(DIFF_CONTEXT_LINES);
+    let mut hunk_end = (change_indices[0] + DIFF_CONTEXT_LINES + 1).min(diff.len());
+
+    for &idx in &change_indices[1..] {
+        let new_start = idx.saturating_sub(DIFF_CONTEXT_LINES);
+        let new_end = (idx + DIFF_CONTEXT_LINES + 1).min(diff.len());
+
+        if new_start <= hunk_end {
+            hunk_end = hunk_end.max(new_end);
+        } else {
+            hunk_ranges.push((hunk_start, hunk_end));
+            hunk_start = new_start;
+            hunk_end = new_end;
+        }
+    }
+    hunk_ranges.push((hunk_start, hunk_end));
+
+    // Render each hunk
+    for (hunk_idx, &(start, end)) in hunk_ranges.iter().enumerate() {
+        // Add separator between hunks
+        if hunk_idx > 0 {
+            let sep_line = format!(
+                "{}  {}{}",
+                DIM,
+                BOX_COLOR,
+                "·".repeat(if show_line_numbers {
+                    num_width + 1 + 3 + 60
+                } else {
+                    3 + 60
+                })
+            );
+            writeln!(stdout, "{}{}", sep_line, RESET)?;
+        }
+
+        // Count line numbers up to the start of this hunk
+        let mut old_num: usize = 0;
+        #[allow(unused_variables)]
+        let mut new_num: usize = 0;
+        for item in diff.iter().take(start) {
+            match item {
+                DiffLine::Keep(_) => {
+                    old_num += 1;
+                    new_num += 1;
+                }
+                DiffLine::Remove(_) => {
+                    old_num += 1;
+                }
+                DiffLine::Add(_) => {
+                    new_num += 1;
+                }
+            }
+        }
+
+        for i in start..end {
+            if i >= diff.len() {
+                break;
+            }
+            match &diff[i] {
+                DiffLine::Keep(line) => {
+                    old_num += 1;
+                    new_num += 1;
+                    if show_line_numbers {
+                        writeln!(
+                            stdout,
+                            "  {:>width$} {} {}",
+                            old_num,
+                            DIM,
+                            line,
+                            width = num_width,
+                        )?;
+                    } else {
+                        writeln!(stdout, "  {} {}{}", DIM, line, RESET)?;
+                    }
+                }
+                DiffLine::Remove(line) => {
+                    old_num += 1;
+                    if show_line_numbers {
+                        writeln!(
+                            stdout,
+                            "{}  {:<width$} {}{} {}",
+                            RED,
+                            "-",
+                            RESET,
+                            RED,
+                            line,
+                            width = num_width
+                        )?;
+                    } else {
+                        writeln!(stdout, "{}  - {}{}", RED, RESET, line)?;
+                    }
+                }
+                DiffLine::Add(line) => {
+                    new_num += 1;
+                    if show_line_numbers {
+                        writeln!(
+                            stdout,
+                            "{}  {:<width$} {}{} {}",
+                            GREEN,
+                            "+",
+                            RESET,
+                            GREEN,
+                            line,
+                            width = num_width
+                        )?;
+                    } else {
+                        writeln!(stdout, "{}  + {}{}", GREEN, RESET, line)?;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
 /// Show a unified-diff-style view of a write operation (full file).
 /// If the file already exists, reads it and shows a line-by-line diff
 /// with removed lines in red and added lines in green.
@@ -40,81 +276,64 @@ pub fn show_write_preview<W: Write>(
 
     let new_lines: Vec<&str> = new_content.lines().collect();
 
+    // Compute the diff
+    let diff = compute_diff(&old_lines, &new_lines);
+
+    // If the file is identical, show a note
+    let has_changes = diff.iter().any(|l| !matches!(l, DiffLine::Keep(_)));
+
+    if !has_changes {
+        writeln!(
+            stdout,
+            "\n{}  ── {}No changes in {}{} ──{}",
+            BOLD, BOX_COLOR, path, BOLD, RESET
+        )?;
+        return Ok(());
+    }
+
+    // Count additions and removals for the header
+    let removals = diff
+        .iter()
+        .filter(|l| matches!(l, DiffLine::Remove(_)))
+        .count();
+    let additions = diff
+        .iter()
+        .filter(|l| matches!(l, DiffLine::Add(_)))
+        .count();
+
     writeln!(
         stdout,
-        "\n{}  ── {}Diff for {}{} ──{}",
-        BOLD, BOX_COLOR, path, BOLD, RESET
+        "\n{}  ── {}Diff for {}{} ── {}{}-{}{}+{}{}",
+        BOLD, BOX_COLOR, path, BOLD, RED, removals, GREEN, additions, RESET, RESET,
     )?;
+
+    let max_line = old_lines.len().max(new_lines.len()).max(1);
+    let num_width = max_line.to_string().len().max(2);
+
+    // Separator line
     writeln!(
         stdout,
-        "{}     {}{} {}",
+        "{}  {}{} {} {}",
         DIM,
         BOX_COLOR,
+        " ".repeat(num_width),
         "┄".repeat(60),
         RESET
     )?;
 
-    // Simple line-by-line diff using LCS-like approach
-    let mut old_idx = 0;
-    let mut new_idx = 0;
+    // Render the diff with line numbers
+    render_diff_lines(stdout, &diff, &old_lines, &new_lines, true)?;
 
-    while old_idx < old_lines.len() || new_idx < new_lines.len() {
-        if old_idx < old_lines.len()
-            && new_idx < new_lines.len()
-            && old_lines[old_idx] == new_lines[new_idx]
-        {
-            // Unchanged line (dim)
-            writeln!(stdout, "  {} {}", DIM, old_lines[old_idx])?;
-            old_idx += 1;
-            new_idx += 1;
-        } else {
-            // Try to find the next matching line to determine what was removed/added
-            let mut found = false;
-            // Look ahead in old (possible removals)
-            for lookahead in 1..=3 {
-                if old_idx + lookahead < old_lines.len()
-                    && new_idx < new_lines.len()
-                    && old_lines[old_idx + lookahead] == new_lines[new_idx]
-                {
-                    for &removed in old_lines.iter().take(old_idx + lookahead).skip(old_idx) {
-                        writeln!(stdout, "{}  - {}{}", RED, RESET, removed)?;
-                    }
-                    old_idx += lookahead;
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                // Look ahead in new (possible additions)
-                for lookahead in 1..=3 {
-                    if new_idx + lookahead < new_lines.len()
-                        && old_idx < old_lines.len()
-                        && new_lines[new_idx + lookahead] == old_lines[old_idx]
-                    {
-                        for &added in new_lines.iter().take(new_idx + lookahead).skip(new_idx) {
-                            writeln!(stdout, "{}  + {}{}", GREEN, RESET, added)?;
-                        }
-                        new_idx += lookahead;
-                        found = true;
-                        break;
-                    }
-                }
-            }
-            if !found {
-                // Can't align — treat as replace
-                if old_idx < old_lines.len() {
-                    writeln!(stdout, "{}  - {}{}", RED, RESET, old_lines[old_idx])?;
-                    old_idx += 1;
-                }
-                if new_idx < new_lines.len() {
-                    writeln!(stdout, "{}  + {}{}", GREEN, RESET, new_lines[new_idx])?;
-                    new_idx += 1;
-                }
-            }
-        }
-    }
-
-    writeln!(stdout, "{}     {} {}", DIM, "┄".repeat(60), RESET)?;
+    // Ending separator
+    writeln!(
+        stdout,
+        "{}  {}{} {} {}",
+        DIM,
+        BOX_COLOR,
+        " ".repeat(num_width),
+        "┄".repeat(60),
+        RESET
+    )?;
 
     Ok(())
 }
@@ -243,4 +462,246 @@ pub fn show_edit_diff<W: Write>(
     )?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_diff_identical() {
+        let old = vec!["a", "b", "c"];
+        let new = vec!["a", "b", "c"];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(
+            diff,
+            vec![
+                DiffLine::Keep("a"),
+                DiffLine::Keep("b"),
+                DiffLine::Keep("c"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_compute_diff_empty_to_lines() {
+        let old: Vec<&str> = vec![];
+        let new = vec!["a", "b"];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(diff, vec![DiffLine::Add("a"), DiffLine::Add("b")]);
+    }
+
+    #[test]
+    fn test_compute_diff_lines_to_empty() {
+        let old = vec!["a", "b"];
+        let new: Vec<&str> = vec![];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(diff, vec![DiffLine::Remove("a"), DiffLine::Remove("b")]);
+    }
+
+    #[test]
+    fn test_compute_diff_simple_insertion() {
+        let old = vec!["a", "c"];
+        let new = vec!["a", "b", "c"];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(
+            diff,
+            vec![DiffLine::Keep("a"), DiffLine::Add("b"), DiffLine::Keep("c"),]
+        );
+    }
+
+    #[test]
+    fn test_compute_diff_simple_deletion() {
+        let old = vec!["a", "b", "c"];
+        let new = vec!["a", "c"];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(
+            diff,
+            vec![
+                DiffLine::Keep("a"),
+                DiffLine::Remove("b"),
+                DiffLine::Keep("c"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_compute_diff_replace() {
+        let old = vec!["a", "old", "c"];
+        let new = vec!["a", "new", "c"];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(
+            diff,
+            vec![
+                DiffLine::Keep("a"),
+                DiffLine::Remove("old"),
+                DiffLine::Add("new"),
+                DiffLine::Keep("c"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_compute_diff_multiple_changes() {
+        let old = vec!["a", "b", "c", "d", "e"];
+        let new = vec!["a", "x", "c", "y", "e"];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(
+            diff,
+            vec![
+                DiffLine::Keep("a"),
+                DiffLine::Remove("b"),
+                DiffLine::Add("x"),
+                DiffLine::Keep("c"),
+                DiffLine::Remove("d"),
+                DiffLine::Add("y"),
+                DiffLine::Keep("e"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_compute_diff_large_shift() {
+        // Lines rearranged: the old "middle" section is removed and new lines added
+        let old = vec!["keep1", "remove1", "remove2", "remove3", "keep2"];
+        let new = vec!["keep1", "add1", "add2", "keep2"];
+        let diff = compute_diff(&old, &new);
+        let keeps: Vec<_> = diff
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Keep(_)))
+            .collect();
+        let removes: Vec<_> = diff
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Remove(_)))
+            .collect();
+        let adds: Vec<_> = diff
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Add(_)))
+            .collect();
+        assert_eq!(keeps.len(), 2);
+        assert_eq!(removes.len(), 3);
+        assert_eq!(adds.len(), 2);
+        // Keep lines should be in order
+        assert!(matches!(keeps[0], DiffLine::Keep("keep1")));
+        assert!(matches!(keeps[1], DiffLine::Keep("keep2")));
+    }
+
+    #[test]
+    fn test_compute_diff_both_empty() {
+        let old: Vec<&str> = vec![];
+        let new: Vec<&str> = vec![];
+        let diff = compute_diff(&old, &new);
+        assert!(diff.is_empty());
+    }
+
+    #[test]
+    fn test_compute_diff_single_line_change() {
+        let old = vec!["hello world"];
+        let new = vec!["hello rust"];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(
+            diff,
+            vec![DiffLine::Remove("hello world"), DiffLine::Add("hello rust")]
+        );
+    }
+
+    #[test]
+    fn test_compute_diff_prepend_and_append() {
+        let old = vec!["b", "c"];
+        let new = vec!["a", "b", "c", "d"];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(
+            diff,
+            vec![
+                DiffLine::Add("a"),
+                DiffLine::Keep("b"),
+                DiffLine::Keep("c"),
+                DiffLine::Add("d"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_compute_diff_minimality() {
+        // The diff should produce the minimum number of edits
+        let old = vec!["a", "b", "c", "d", "e", "f"];
+        let new = vec!["a", "c", "d", "e", "g"];
+        let diff = compute_diff(&old, &new);
+        let removes = diff
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Remove(_)))
+            .count();
+        let adds = diff
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Add(_)))
+            .count();
+        // Minimum: remove b, remove f, add g = 2 removes + 1 add = 3 edits
+        assert_eq!(removes, 2);
+        assert_eq!(adds, 1);
+    }
+
+    #[test]
+    fn test_compute_diff_longer_file() {
+        // A more realistic scenario with many lines
+        let old: Vec<String> = (0..50).map(|i| format!("line {}", i)).collect();
+        let mut new = old.clone();
+        // Change lines 10, 20, remove line 30, insert after line 40
+        new[10] = "line 10 modified".to_string();
+        new[20] = "line 20 modified".to_string();
+        new.remove(30);
+        new.insert(41, "inserted line".to_string());
+
+        let old_refs: Vec<&str> = old.iter().map(|s| s.as_str()).collect();
+        let new_refs: Vec<&str> = new.iter().map(|s| s.as_str()).collect();
+
+        let diff = compute_diff(&old_refs, &new_refs);
+
+        let removes = diff
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Remove(_)))
+            .count();
+        let adds = diff
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Add(_)))
+            .count();
+        // 3 removals (line 10 original, line 20 original, line 30) and 3 additions
+        // (modified 10, modified 20, inserted)
+        assert_eq!(removes, 3);
+        assert_eq!(adds, 3);
+    }
+
+    #[test]
+    fn test_compute_diff_reorder() {
+        // Swapping two unique lines
+        let old = vec!["alpha", "beta"];
+        let new = vec!["beta", "alpha"];
+        let diff = compute_diff(&old, &new);
+        // Both lines exist in both files, so one should be kept.
+        // The minimal diff removes and re-adds the reordered line.
+        let keeps = diff
+            .iter()
+            .filter(|l| matches!(l, DiffLine::Keep(_)))
+            .count();
+        assert!(keeps >= 1, "At least one line should be kept in a reorder");
+    }
+
+    #[test]
+    fn test_compute_diff_all_same_then_change() {
+        // Large common prefix, then a change
+        let old: Vec<&str> = vec!["line1", "line2", "line3", "line4", "line5", "old_ending"];
+        let new: Vec<&str> = vec!["line1", "line2", "line3", "line4", "line5", "new_ending"];
+        let diff = compute_diff(&old, &new);
+        assert_eq!(
+            diff,
+            vec![
+                DiffLine::Keep("line1"),
+                DiffLine::Keep("line2"),
+                DiffLine::Keep("line3"),
+                DiffLine::Keep("line4"),
+                DiffLine::Keep("line5"),
+                DiffLine::Remove("old_ending"),
+                DiffLine::Add("new_ending"),
+            ]
+        );
+    }
 }

--- a/src/ui/wrap.rs
+++ b/src/ui/wrap.rs
@@ -1,25 +1,31 @@
 use std::{error::Error, io::Write};
 
+use crate::style::FILL_EOL;
+
 /// Maximum line width for word-wrapped output.
 pub const MAX_LINE_WIDTH: usize = 120;
 
 /// Write lines to stdout with word-wrapping at `max_width` characters.
 /// Lines shorter than `max_width - indent.len()` are written as-is.
 /// Empty lines produce just a newline.
+/// When `fill_bg` is true, each line is suffixed with `FILL_EOL` to fill
+/// the background color to the end of the terminal line.
 pub fn write_wrapped_lines<W: Write>(
     stdout: &mut W,
     content: &str,
     base_indent: &str,
     cont_indent: &str,
     max_width: usize,
+    fill_bg: bool,
 ) -> Result<(), Box<dyn Error>> {
+    let suffix = if fill_bg { FILL_EOL } else { "" };
     for line in content.lines() {
         if line.is_empty() {
-            writeln!(stdout)?;
+            writeln!(stdout, "{}", suffix)?;
             continue;
         }
         if line.len() <= max_width - base_indent.len() {
-            writeln!(stdout, "{}{}", base_indent, line)?;
+            writeln!(stdout, "{}{}{}", base_indent, line, suffix)?;
             continue;
         }
         // Word-wrap long lines
@@ -29,7 +35,7 @@ pub fn write_wrapped_lines<W: Write>(
             let indent = if first { base_indent } else { cont_indent };
             let avail = max_width - indent.len();
             if remaining.len() <= avail {
-                writeln!(stdout, "{}{}", indent, remaining)?;
+                writeln!(stdout, "{}{}{}", indent, remaining, suffix)?;
                 break;
             }
             let chunk_end = remaining.floor_char_boundary(avail);
@@ -37,10 +43,10 @@ pub fn write_wrapped_lines<W: Write>(
             let split_at = chunk.rfind(' ').unwrap_or(chunk_end);
             if split_at == 0 {
                 // No space found at all — just break at the width limit
-                writeln!(stdout, "{}{}", indent, &remaining[..chunk_end])?;
+                writeln!(stdout, "{}{}{}", indent, &remaining[..chunk_end], suffix)?;
                 remaining = remaining[chunk_end..].trim_start();
             } else {
-                writeln!(stdout, "{}{}", indent, &chunk[..split_at])?;
+                writeln!(stdout, "{}{}{}", indent, &chunk[..split_at], suffix)?;
                 remaining = remaining[chunk[..split_at].len()..].trim_start();
             }
             first = false;


### PR DESCRIPTION

This branch brings significant improvements to the terminal UI — making tool calls more visible, LLM responses more informative, and file diffs far more accurate.

### Changes (5 commits, +916 / −198 lines across 7 files)

**Spinner animation during waiting** (`53a0320`)
- Braille-pattern spinner while waiting for the first LLM content chunk ("⠋ Thinking...")
- Spinner animation while waiting for tool execution results
- Uses `tokio::select!` for non-blocking animation that clears cleanly when content arrives

**Context status & prompt improvements** (`d04245c`, `3303c98`, `2b9a6a7`)
- Compact pi-style status line in the prompt: `5 msgs · 1.2K/8K (15%) · 2 pinned` with color-coded usage warnings
- Session name shown in the prompt: `(session_name)`
- Model name displayed next to mode label: `[agent] llama3.2:latest>`
- Duration display on tool results: `✓ run 1.2s`
- Success/fail indicators (✓/✗) with color-coded result summaries
- Background-highlighted tool call blocks (`BG_DIM`/`BG_TOOL`)
- Readable confirmation prompt with diff previews, word-wrapped command display

**LCS-based diff algorithm** (`39c9940`)
- Replaced the old greedy lookahead-3 diff in `show_write_preview` with a proper LCS (Longest Common Subsequence) dynamic programming algorithm
- Produces optimal minimum-edit diffs — same quality as `git diff`
- Unified-diff-style output with `+`/`-` line markers, line numbers, and 3-line context around changes
- Hunks merged when overlapping, with `·` separators between distant changes
- Change statistics in header: `Diff for file.rs ─ 3-2+1`
- Detects identical files and shows "No changes" instead of a useless full-file diff
- 12 new unit tests covering edge cases (empty files, single-line changes, reorders, long files, etc.)

### Files changed
| File | Changes |
|---|---|
| `src/agent/mod.rs` | Spinner, model name in prompt, session name in prompt |
| `src/agent/tools.rs` | Spinner for tool execution, duration display, success/fail indicators |
| `src/agent/display.rs` | Context status line, conversation history formatting |
| `src/style.rs` | `SPINNER_FRAMES`, `CLEAR_LINE` constants |
| `src/ui/diff.rs` | LCS diff algorithm, hunk rendering, `DiffLine` enum |
| `src/ui/confirm.rs` | Word-wrapped command display, confirmation prompt styling |
| `src/ui/wrap.rs` | Minor adjustments to word-wrapping |