### PR TITLE
feat: openai-compat bearer auth + skip health check

### DIFF
--- a/src/agent/setup.rs
+++ b/src/agent/setup.rs
@@ -234,6 +234,38 @@ pub fn save_provider_settings(kind: ProviderKind, url: &str) {
     save_settings(&s);
 }
 
+/// Resolve the bearer token for OpenAI-compatible providers using the
+/// precedence:
+///
+/// 1. `cli_api_key` (the value of `--api-key` if passed; empty string is
+///    treated as "no key requested" and short-circuits to `None`).
+/// 2. `OPENAI_API_KEY` environment variable, if set and non-empty.
+/// 3. `settings.openai_compat_api_key`, if set.
+///
+/// When `cli_api_key` is non-empty it is also persisted to settings so that
+/// subsequent launches pick it up automatically without `--api-key`.
+///
+/// Returns `None` when no key should be sent. The Ollama and Sockudo providers
+/// ignore this value entirely.
+pub fn resolve_api_key(cli_api_key: &str, settings: &Settings) -> Option<String> {
+    if !cli_api_key.is_empty() {
+        let key = cli_api_key.to_string();
+        let mut s = load_settings();
+        s.openai_compat_api_key = Some(key.clone());
+        save_settings(&s);
+        return Some(key);
+    }
+    if let Ok(env_key) = std::env::var("OPENAI_API_KEY")
+        && !env_key.is_empty()
+    {
+        return Some(env_key);
+    }
+    settings
+        .openai_compat_api_key
+        .clone()
+        .filter(|s| !s.is_empty())
+}
+
 /// Persist an API key change based on the user's choice.
 pub fn apply_api_key_choice(choice: ApiKeyChoice) -> bool {
     let mut s = load_settings();

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,19 @@ struct Args {
     #[arg(short, long, default_value_t = String::new())]
     url: String,
 
+    /// Bearer token for OpenAI-compatible providers (llama.cpp, vLLM, and any
+    /// server exposing `/v1/chat/completions`). Sent as `Authorization: Bearer
+    /// <key>`. Overrides the saved setting and the `OPENAI_API_KEY` env var.
+    /// Use `--api-key ""` to clear. Has no effect on Ollama or Sockudo.
+    #[arg(long, default_value_t = String::new())]
+    api_key: String,
+
+    /// Skip the provider health check at startup. Useful when the server
+    /// requires a separate scope on `/health`, doesn't expose one, or you
+    /// want the agent to start fast and surface errors on the first request.
+    #[arg(long)]
+    skip_health_check: bool,
+
     /// Continue the most recent session in the current directory.
     #[arg(short, long)]
     r#continue: bool,
@@ -95,11 +108,15 @@ fn resolve_provider_kind(args: &Args, settings: &Settings) -> ProviderKind {
 async fn create_provider(
     kind: ProviderKind,
     url: String,
+    api_key: Option<String>,
+    skip_health_check: bool,
     settings: &Settings,
 ) -> Arc<Mutex<dyn Provider + Send + Sync>> {
     let provider: Arc<Mutex<dyn Provider + Send + Sync>> = match kind {
-        ProviderKind::LlamaCpp => Arc::new(Mutex::new(LlamaCppProvider::new(url))),
-        ProviderKind::Vllm => Arc::new(Mutex::new(VllmProvider::new(url))),
+        ProviderKind::LlamaCpp => {
+            Arc::new(Mutex::new(LlamaCppProvider::with_api_key(url, api_key)))
+        }
+        ProviderKind::Vllm => Arc::new(Mutex::new(VllmProvider::with_api_key(url, api_key))),
         ProviderKind::Ollama => Arc::new(Mutex::new(OllamaProvider::new(
             url,
             settings.ollama_timeout_secs,
@@ -117,7 +134,8 @@ async fn create_provider(
     };
 
     // Run health check for all providers (Ollama included)
-    {
+    // Skipped when the CLI flag or settings flag is set.
+    if !skip_health_check {
         let p = provider.lock().await;
         if let Err(e) = p.health_check().await {
             let mut err_out = Output::stderr();
@@ -127,6 +145,12 @@ async fn create_provider(
             );
             std::process::exit(1);
         }
+    } else {
+        let mut err_out = Output::stderr();
+        let _ = writeln!(
+            err_out,
+            "{BOLD}{kind}:{RESET} Skipping health check (--skip-health-check).",
+        );
     }
 
     provider
@@ -406,7 +430,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         args.url.clone()
     };
 
-    let provider = create_provider(provider_kind, url.clone(), &settings).await;
+    let api_key = agent_setup::resolve_api_key(&args.api_key, &settings);
+    let skip_hc = args.skip_health_check || settings.skip_health_check;
+    let provider = create_provider(provider_kind, url.clone(), api_key, skip_hc, &settings).await;
 
     // Auto-select model if none is currently set.
     // Sockudo doesn't use a saved model — the worker selects the backend

--- a/tinyharness-lib/src/config/mod.rs
+++ b/tinyharness-lib/src/config/mod.rs
@@ -329,6 +329,12 @@ pub struct Settings {
     pub last_model: Option<String>,
     pub preferred_mode: AgentMode,
     pub ollama_api_key: Option<String>,
+    /// API key sent as `Authorization: Bearer <key>` by OpenAI-compatible
+    /// providers (llama.cpp, vLLM, and any server exposing the
+    /// `/v1/chat/completions` endpoint). Set via `--api-key` or
+    /// `OPENAI_API_KEY` env var. Leave `None` for local unauthenticated servers.
+    #[serde(default)]
+    pub openai_compat_api_key: Option<String>,
     /// Sockudo app ID for the AI Transport provider.
     #[serde(default)]
     pub sockudo_app_id: Option<String>,
@@ -350,6 +356,13 @@ pub struct Settings {
     pub context_limit: Option<u32>,
     /// Automatically accept safe read-only commands in the run tool (default: true)
     pub auto_accept_safe_commands: bool,
+    /// Skip the provider health check at startup (default: false).
+    /// Useful for hosted OpenAI-compatible gateways that require a separate
+    /// scope on `/health`, or for self-hosted servers without a `/health`
+    /// endpoint. When true, the agent proceeds straight to model selection
+    /// and reports any connection error on the first real request instead.
+    #[serde(default)]
+    pub skip_health_check: bool,
     /// List of command prefixes considered safe for auto-accept (default: see get_default_safe_commands)
     pub safe_command_prefixes: Option<Vec<String>>,
     /// List of command prefixes that are always denied auto-accept, even if they
@@ -371,6 +384,7 @@ impl Default for Settings {
             last_model: None,
             preferred_mode: AgentMode::Casual,
             ollama_api_key: None,
+            openai_compat_api_key: None,
             sockudo_app_id: None,
             sockudo_app_key: None,
             sockudo_app_secret: None,
@@ -380,6 +394,7 @@ impl Default for Settings {
             show_thinking: false,
             context_limit: None,
             auto_accept_safe_commands: true,
+            skip_health_check: false,
             safe_command_prefixes: None,
             denied_command_prefixes: None,
             project_md_files: None,

--- a/tinyharness-lib/src/provider/llama_cpp.rs
+++ b/tinyharness-lib/src/provider/llama_cpp.rs
@@ -11,8 +11,14 @@ pub struct LlamaCppProvider {
 
 impl LlamaCppProvider {
     pub fn new(base_url: String) -> Self {
+        Self::with_api_key(base_url, None)
+    }
+
+    /// Create a new llama.cpp provider, optionally sending an
+    /// `Authorization: Bearer <api_key>` header on every request.
+    pub fn with_api_key(base_url: String, api_key: Option<String>) -> Self {
         LlamaCppProvider {
-            inner: OpenAiCompatInner::new(base_url),
+            inner: OpenAiCompatInner::with_api_key(base_url, api_key),
         }
     }
 }

--- a/tinyharness-lib/src/provider/openai_compat.rs
+++ b/tinyharness-lib/src/provider/openai_compat.rs
@@ -13,16 +13,26 @@ use crate::provider::{
 
 /// Shared inner state for OpenAI-compatible providers (llama.cpp, vLLM, etc.).
 ///
-/// Encapsulates the common `{client, base_url, model}` fields and all shared
-/// logic so that provider implementations only need to differ in `list_models()`.
+/// Encapsulates the common `{client, base_url, model, api_key}` fields and all
+/// shared logic so that provider implementations only need to differ in
+/// `list_models()`.
 pub struct OpenAiCompatInner {
     client: Client,
     base_url: String,
     model: Option<String>,
+    /// Optional bearer token sent as `Authorization: Bearer <key>` on every
+    /// request. Used by hosted OpenAI-compatible APIs (e.g. OpenRouter,
+    /// Together, self-hosted gateways) that require authentication.
+    api_key: Option<String>,
 }
 
 impl OpenAiCompatInner {
     pub fn new(base_url: String) -> Self {
+        Self::with_api_key(base_url, None)
+    }
+
+    /// Create a new inner state with an optional bearer token.
+    pub fn with_api_key(base_url: String, api_key: Option<String>) -> Self {
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(15))
             .read_timeout(Duration::from_secs(300))
@@ -32,6 +42,7 @@ impl OpenAiCompatInner {
             client,
             base_url,
             model: None,
+            api_key,
         }
     }
 
@@ -39,8 +50,13 @@ impl OpenAiCompatInner {
     pub fn health_check(&self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send>> {
         let url = format!("{}/health", self.base_url.trim_end_matches('/'));
         let client = self.client.clone();
+        let api_key = self.api_key.clone();
         Box::pin(async move {
-            match client.get(&url).send().await {
+            let mut req = client.get(&url);
+            if let Some(key) = &api_key {
+                req = req.bearer_auth(key);
+            }
+            match req.send().await {
                 Ok(resp) if resp.status().is_success() => Ok(()),
                 Ok(resp) => Err(format!(
                     "Server returned {}: {}",
@@ -74,8 +90,13 @@ impl OpenAiCompatInner {
         let url = format!("{}/v1/models", self.base_url.trim_end_matches('/'));
         let client = self.client.clone();
         let current_model = self.model.clone();
+        let api_key = self.api_key.clone();
         Box::pin(async move {
-            match client.get(&url).send().await {
+            let mut req = client.get(&url);
+            if let Some(key) = &api_key {
+                req = req.bearer_auth(key);
+            }
+            match req.send().await {
                 Ok(resp) if resp.status().is_success() => {
                     match resp.json::<ModelListResponse>().await {
                         Ok(list) => list.data.into_iter().map(|m| m.id).collect(),
@@ -107,6 +128,7 @@ impl OpenAiCompatInner {
         let openai_tools = tools.into_iter().map(to_openai_tool).collect();
         let client = self.client.clone();
         let chat_url = self.chat_url();
+        let api_key = self.api_key.clone();
 
         let body = ChatRequest {
             model,
@@ -120,7 +142,8 @@ impl OpenAiCompatInner {
 
         // Spawn the streaming work on a background task
         tokio::spawn(async move {
-            let _usage = stream_chat_completions(&client, &chat_url, &body, &send).await;
+            let _usage =
+                stream_chat_completions(&client, &chat_url, &body, api_key.as_deref(), &send).await;
         });
 
         Box::pin(async move { Ok(recv) })
@@ -331,13 +354,21 @@ pub fn to_openai_tool(ti: ToolDefinition) -> OpenAITool {
 /// Stream chat completions from an OpenAI-compatible endpoint.
 /// Returns accumulated tool calls and final content via the sender.
 /// Also returns the token usage if available.
+///
+/// If `api_key` is `Some`, the request includes an
+/// `Authorization: Bearer <key>` header.
 pub async fn stream_chat_completions(
     client: &reqwest::Client,
     url: &str,
     body: &ChatRequest,
+    api_key: Option<&str>,
     send: &tokio::sync::mpsc::Sender<ChatMessageResponse>,
 ) -> Option<crate::provider::TokenUsage> {
-    let response = match client.post(url).json(body).send().await {
+    let mut request = client.post(url).json(body);
+    if let Some(key) = api_key {
+        request = request.bearer_auth(key);
+    }
+    let response = match request.send().await {
         Ok(r) => r,
         Err(e) => {
             let _ = send

--- a/tinyharness-lib/src/provider/vllm.rs
+++ b/tinyharness-lib/src/provider/vllm.rs
@@ -11,8 +11,14 @@ pub struct VllmProvider {
 
 impl VllmProvider {
     pub fn new(base_url: String) -> Self {
+        Self::with_api_key(base_url, None)
+    }
+
+    /// Create a new vLLM provider, optionally sending an
+    /// `Authorization: Bearer <api_key>` header on every request.
+    pub fn with_api_key(base_url: String, api_key: Option<String>) -> Self {
         VllmProvider {
-            inner: OpenAiCompatInner::new(base_url),
+            inner: OpenAiCompatInner::with_api_key(base_url, api_key),
         }
     }
 }


### PR DESCRIPTION
## The problem

I use TinyHarness with a hosted OpenAI-compatible server (OpenRouter-style) and it rejects every request because there's no way to send an API key. Also the health check hits /health which needs a different scope on my server, so TinyHarness can't even start.

## What this adds

**Bearer auth for OpenAI-compat providers (llama.cpp, vLLM, any /v1/chat/completions server):**

- New setting: `openai_compat_api_key` in settings.json
- New CLI flag: `--api-key <KEY>`
- Env fallback: `OPENAI_API_KEY`
- Precedence: `--api-key` > env > settings
- The key is injected via `OpenAiCompatInner` so both LlamaCpp and vLLM get it with no duplication

**Skip health check for gateways without a /health endpoint (or with restricted scopes):**

- New setting: `skip_health_check` in settings.json
- New CLI flag: `--skip-health-check`
- Precedence: CLI or settings.json
- When skipped, logs a notice and proceeds to model selection; errors show up on the first real request

## Testing

Tested against a live OpenRouter-style server that requires Bearer auth and returns 401 on /health. With both features set, the agent starts and streams responses correctly.

```
tinyharness --vllm --url http://myserver:8080 --api-key sk-xxx -p "say OK"
```