### PR TITLE
fix: tool_call_id missing + non-2xx responses silently dropped

### DIFF
--- a/src/agent/command_result.rs
+++ b/src/agent/command_result.rs
@@ -136,6 +136,7 @@ pub fn apply_skill_use(
                 role: Role::User,
                 content: format!("/use {}", skill_name),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             });
             session.append_message(messages.last().expect("just pushed a message"));
@@ -175,6 +176,7 @@ pub fn apply_skill_unload(
                 role: Role::User,
                 content: format!("/unload {}", skill_name),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             });
             session.append_message(messages.last().expect("just pushed a message"));

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -303,6 +303,7 @@ pub async fn run_agent_loop(
             role: Role::User,
             content: user_input.clone(),
             tool_calls: vec![],
+            tool_call_id: None,
             images: pending_images,
         });
 
@@ -487,6 +488,7 @@ pub async fn run_agent_loop(
                         role: Role::Assistant,
                         content: response_content,
                         tool_calls: vec![],
+                        tool_call_id: None,
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -564,6 +566,7 @@ pub async fn run_agent_loop(
                 role: Role::Assistant,
                 content: response_content,
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             });
             session.append_message(messages.last().expect("just pushed a message"));

--- a/src/agent/setup.rs
+++ b/src/agent/setup.rs
@@ -234,6 +234,38 @@ pub fn save_provider_settings(kind: ProviderKind, url: &str) {
     save_settings(&s);
 }
 
+/// Resolve the bearer token for OpenAI-compatible providers using the
+/// precedence:
+///
+/// 1. `cli_api_key` (the value of `--api-key` if passed; empty string is
+///    treated as "no key requested" and short-circuits to `None`).
+/// 2. `OPENAI_API_KEY` environment variable, if set and non-empty.
+/// 3. `settings.openai_compat_api_key`, if set.
+///
+/// When `cli_api_key` is non-empty it is also persisted to settings so that
+/// subsequent launches pick it up automatically without `--api-key`.
+///
+/// Returns `None` when no key should be sent. The Ollama and Sockudo providers
+/// ignore this value entirely.
+pub fn resolve_api_key(cli_api_key: &str, settings: &Settings) -> Option<String> {
+    if !cli_api_key.is_empty() {
+        let key = cli_api_key.to_string();
+        let mut s = load_settings();
+        s.openai_compat_api_key = Some(key.clone());
+        save_settings(&s);
+        return Some(key);
+    }
+    if let Ok(env_key) = std::env::var("OPENAI_API_KEY")
+        && !env_key.is_empty()
+    {
+        return Some(env_key);
+    }
+    settings
+        .openai_compat_api_key
+        .clone()
+        .filter(|s| !s.is_empty())
+}
+
 /// Persist an API key change based on the user's choice.
 pub fn apply_api_key_choice(choice: ApiKeyChoice) -> bool {
     let mut s = load_settings();

--- a/src/agent/signal.rs
+++ b/src/agent/signal.rs
@@ -90,6 +90,7 @@ pub async fn handle_signal_event(
                             old_mode, mode, mode
                         ),
                         tool_calls: vec![],
+                        tool_call_id: None,
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -104,6 +105,7 @@ pub async fn handle_signal_event(
                         role: Role::Tool,
                         content: format!("Already in '{}' mode. No change was made.", mode),
                         tool_calls: vec![],
+                        tool_call_id: None,
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -152,6 +154,7 @@ pub async fn handle_signal_event(
                             }
                         ),
                         tool_calls: vec![],
+                        tool_call_id: None,
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -169,6 +172,7 @@ pub async fn handle_signal_event(
                             e
                         ),
                         tool_calls: vec![],
+                        tool_call_id: None,
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -199,6 +203,7 @@ pub async fn handle_signal_event(
                             role: Role::Tool,
                             content: format!("Skill '{}' is already active. Its instructions are already in effect.", name),
                             tool_calls: vec![],
+                            tool_call_id: None,
                             images: vec![],
                         });
                         session.append_message(messages.last().expect("just pushed a message"));
@@ -214,6 +219,7 @@ pub async fn handle_signal_event(
                             role: Role::User,
                             content: format!("/use {}", skill_name),
                             tool_calls: vec![],
+                            tool_call_id: None,
                             images: vec![],
                         });
                         session.append_message(messages.last().expect("just pushed a message"));
@@ -241,6 +247,7 @@ pub async fn handle_signal_event(
                             skill_name, available
                         ),
                         tool_calls: vec![],
+                        tool_call_id: None,
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -282,6 +289,7 @@ pub fn apply_question_answer(
         role: Role::Tool,
         content: result_content,
         tool_calls: vec![],
+        tool_call_id: None,
         images: vec![],
     });
     session.append_message(messages.last().expect("just pushed a message"));
@@ -310,6 +318,7 @@ pub fn apply_question_error(error: String, messages: &mut Vec<Message>, session:
         role: Role::Tool,
         content: error,
         tool_calls: vec![],
+        tool_call_id: None,
         images: vec![],
     });
     session.append_message(messages.last().expect("just pushed a message"));
@@ -328,6 +337,7 @@ pub fn apply_signal_parse_error(
             tool_name
         ),
         tool_calls: vec![],
+        tool_call_id: None,
         images: vec![],
     });
     session.append_message(messages.last().expect("just pushed a message"));

--- a/src/agent/tool_result.rs
+++ b/src/agent/tool_result.rs
@@ -58,6 +58,7 @@ pub fn batch_tool_results(results: Vec<GenericToolResult>) -> Option<Message> {
             batched_content
         ),
         tool_calls: vec![],
+        tool_call_id: None,
         images: all_images,
     })
 }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -53,6 +53,7 @@ pub async fn handle_tool_calls<W: Write>(
         role: Role::Assistant,
         content: response_content.to_string(),
         tool_calls: tool_calls.to_vec(),
+        tool_call_id: None,
         images: vec![],
     });
     session.append_message(messages.last().expect("just pushed a message"));
@@ -151,6 +152,7 @@ pub async fn handle_tool_calls<W: Write>(
                     "[Tool denied] The user denied the '{}' tool call with arguments: {}\n\nTell the user you cannot proceed with that action unless they approve it.",
                     call.function.name, args_summary
                 ),
+                tool_call_id: None,
                 tool_calls: vec![], images: vec![],
             });
             session.append_message(messages.last().expect("just pushed a message"));

--- a/src/agent/tui_loop.rs
+++ b/src/agent/tui_loop.rs
@@ -444,6 +444,7 @@ async fn process_user_message(
         role: Role::User,
         content: text.to_string(),
         tool_calls: vec![],
+        tool_call_id: None,
         images: pending_images,
     });
 
@@ -556,6 +557,7 @@ async fn process_user_message(
                                 role: Role::Assistant,
                                 content: response_content,
                                 tool_calls: vec![],
+                                tool_call_id: None,
                                 images: vec![],
                             });
                             session.append_message(messages.last().expect("just pushed a message"));
@@ -601,6 +603,7 @@ async fn process_user_message(
                 role: Role::Assistant,
                 content: response_content.clone(),
                 tool_calls: tool_calls.clone(),
+                tool_call_id: None,
                 images: vec![],
             });
             session.append_message(messages.last().expect("just pushed a message"));
@@ -634,6 +637,7 @@ async fn process_user_message(
             role: Role::Assistant,
             content: response_content,
             tool_calls: vec![],
+            tool_call_id: None,
             images: vec![],
         });
         session.append_message(messages.last().expect("just pushed a message"));
@@ -858,6 +862,7 @@ async fn handle_tui_tool_calls(
                     call.function.name, args_summary
                 ),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             });
             session.append_message(messages.last().expect("just pushed a message"));

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -113,12 +113,12 @@ async fn call_llm_summarize(
                        Preserve all technical details: file paths, code snippets, error messages, decisions made, \
                        and current task status. Do NOT add information that was not in the original conversation."
                 .to_string(),
-            tool_calls: vec![], images: vec![],
+            tool_calls: vec![], tool_call_id: None, images: vec![],
         },
         Message {
             role: Role::User,
             content: format!("{}\n\n{}", summarization_prompt, text_to_summarize),
-            tool_calls: vec![], images: vec![],
+            tool_calls: vec![], tool_call_id: None, images: vec![],
         },
     ];
 
@@ -390,6 +390,7 @@ fn reconstruct_messages(
             role: Role::System,
             content: merged_content,
             tool_calls: sys.tool_calls,
+            tool_call_id: sys.tool_call_id,
             images: sys.images,
         });
     }
@@ -420,6 +421,7 @@ mod tests {
             role: Role::User,
             content: long_content,
             tool_calls: vec![],
+            tool_call_id: None,
             images: vec![],
         };
         let formatted = format_messages_for_summary(&[&msg]);
@@ -437,6 +439,7 @@ mod tests {
             role: Role::Assistant,
             content: "Hello world".to_string(),
             tool_calls: vec![],
+            tool_call_id: None,
             images: vec![],
         };
         let formatted = format_messages_for_summary(&[&msg]);
@@ -450,24 +453,28 @@ mod tests {
                 role: Role::System,
                 content: "sys".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::User,
                 content: "usr".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::Assistant,
                 content: "ast".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::Tool,
                 content: "tol".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
         ];
@@ -512,6 +519,7 @@ mod tests {
             role: Role::System,
             content: "You are helpful.".to_string(),
             tool_calls: vec![],
+            tool_call_id: None,
             images: vec![],
         };
         let mut messages = vec![
@@ -520,48 +528,56 @@ mod tests {
                 role: Role::User,
                 content: "msg1".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::Assistant,
                 content: "msg2".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::User,
                 content: "msg3".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::Assistant,
                 content: "msg4".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::User,
                 content: "recent1".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::Assistant,
                 content: "recent2".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::User,
                 content: "recent3".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
             Message {
                 role: Role::Assistant,
                 content: "recent4".to_string(),
                 tool_calls: vec![],
+                tool_call_id: None,
                 images: vec![],
             },
         ];

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -552,12 +552,14 @@ mod tests {
                 role: Role::Assistant,
                 content: "I'll read that file.".to_string(),
                 tool_calls: vec![ToolCall {
+                    id: None,
                     function: tinyharness_lib::provider::ToolCallFunction {
                         name: "read".to_string(),
                         arguments: serde_json::json!({"path": "/tmp/test.rs"}),
                         thought_signature: None,
                     },
                 }],
+                tool_call_id: None,
                 images: vec![],
             },
             Message::simple(Role::Tool, "file contents here"),

--- a/src/commands/files.rs
+++ b/src/commands/files.rs
@@ -370,6 +370,7 @@ mod tests {
             role: Role::System,
             content: "You are a helpful assistant.".to_string(),
             tool_calls: vec![],
+            tool_call_id: None,
             images: vec![],
         }];
 
@@ -388,7 +389,7 @@ mod tests {
         let mut messages = vec![Message {
             role: Role::System,
             content: "Base prompt\n\nThe following files are pinned in context\n--- old ---\nold content\n--- End of pinned files ---".to_string(),
-            tool_calls: vec![], images: vec![],
+            tool_calls: vec![], tool_call_id: None, images: vec![],
         }];
 
         inject_into_system_prompt(&mut messages, &ctx);

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -82,12 +82,12 @@ pub async fn execute_init(
                        this project. Be specific, concise, and factual. Focus on things an AI cannot infer from \
                        the code alone: build commands, conventions, gotchas, architecture decisions. \
                        Output ONLY the raw markdown content — no code fences, no explanations before or after.".to_string(),
-            tool_calls: vec![], images: vec![],
+            tool_calls: vec![], tool_call_id: None, images: vec![],
         },
         Message {
             role: Role::User,
             content: prompt,
-            tool_calls: vec![], images: vec![],
+            tool_calls: vec![], tool_call_id: None, images: vec![],
         },
     ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,19 @@ struct Args {
     #[arg(short, long, default_value_t = String::new())]
     url: String,
 
+    /// Bearer token for OpenAI-compatible providers (llama.cpp, vLLM, and any
+    /// server exposing `/v1/chat/completions`). Sent as `Authorization: Bearer
+    /// <key>`. Overrides the saved setting and the `OPENAI_API_KEY` env var.
+    /// Use `--api-key ""` to clear. Has no effect on Ollama or Sockudo.
+    #[arg(long, default_value_t = String::new())]
+    api_key: String,
+
+    /// Skip the provider health check at startup. Useful when the server
+    /// requires a separate scope on `/health`, doesn't expose one, or you
+    /// want the agent to start fast and surface errors on the first request.
+    #[arg(long)]
+    skip_health_check: bool,
+
     /// Continue the most recent session in the current directory.
     #[arg(short, long)]
     r#continue: bool,
@@ -95,11 +108,15 @@ fn resolve_provider_kind(args: &Args, settings: &Settings) -> ProviderKind {
 async fn create_provider(
     kind: ProviderKind,
     url: String,
+    api_key: Option<String>,
+    skip_health_check: bool,
     settings: &Settings,
 ) -> Arc<Mutex<dyn Provider + Send + Sync>> {
     let provider: Arc<Mutex<dyn Provider + Send + Sync>> = match kind {
-        ProviderKind::LlamaCpp => Arc::new(Mutex::new(LlamaCppProvider::new(url))),
-        ProviderKind::Vllm => Arc::new(Mutex::new(VllmProvider::new(url))),
+        ProviderKind::LlamaCpp => {
+            Arc::new(Mutex::new(LlamaCppProvider::with_api_key(url, api_key)))
+        }
+        ProviderKind::Vllm => Arc::new(Mutex::new(VllmProvider::with_api_key(url, api_key))),
         ProviderKind::Ollama => Arc::new(Mutex::new(OllamaProvider::new(
             url,
             settings.ollama_timeout_secs,
@@ -117,7 +134,8 @@ async fn create_provider(
     };
 
     // Run health check for all providers (Ollama included)
-    {
+    // Skipped when the CLI flag or settings flag is set.
+    if !skip_health_check {
         let p = provider.lock().await;
         if let Err(e) = p.health_check().await {
             let mut err_out = Output::stderr();
@@ -127,6 +145,12 @@ async fn create_provider(
             );
             std::process::exit(1);
         }
+    } else {
+        let mut err_out = Output::stderr();
+        let _ = writeln!(
+            err_out,
+            "{BOLD}{kind}:{RESET} Skipping health check (--skip-health-check).",
+        );
     }
 
     provider
@@ -406,7 +430,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         args.url.clone()
     };
 
-    let provider = create_provider(provider_kind, url.clone(), &settings).await;
+    let api_key = agent_setup::resolve_api_key(&args.api_key, &settings);
+    let skip_hc = args.skip_health_check || settings.skip_health_check;
+    let provider = create_provider(provider_kind, url.clone(), api_key, skip_hc, &settings).await;
 
     // Auto-select model if none is currently set.
     // Sockudo doesn't use a saved model — the worker selects the backend

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,7 @@ fn create_initial_session(
         role: Role::System,
         content: system_prompt,
         tool_calls: vec![],
+        tool_call_id: None,
         images: vec![],
     }];
     (sess, msgs)

--- a/tinyharness-lib/src/config/mod.rs
+++ b/tinyharness-lib/src/config/mod.rs
@@ -329,6 +329,12 @@ pub struct Settings {
     pub last_model: Option<String>,
     pub preferred_mode: AgentMode,
     pub ollama_api_key: Option<String>,
+    /// API key sent as `Authorization: Bearer <key>` by OpenAI-compatible
+    /// providers (llama.cpp, vLLM, and any server exposing the
+    /// `/v1/chat/completions` endpoint). Set via `--api-key` or
+    /// `OPENAI_API_KEY` env var. Leave `None` for local unauthenticated servers.
+    #[serde(default)]
+    pub openai_compat_api_key: Option<String>,
     /// Sockudo app ID for the AI Transport provider.
     #[serde(default)]
     pub sockudo_app_id: Option<String>,
@@ -350,6 +356,13 @@ pub struct Settings {
     pub context_limit: Option<u32>,
     /// Automatically accept safe read-only commands in the run tool (default: true)
     pub auto_accept_safe_commands: bool,
+    /// Skip the provider health check at startup (default: false).
+    /// Useful for hosted OpenAI-compatible gateways that require a separate
+    /// scope on `/health`, or for self-hosted servers without a `/health`
+    /// endpoint. When true, the agent proceeds straight to model selection
+    /// and reports any connection error on the first real request instead.
+    #[serde(default)]
+    pub skip_health_check: bool,
     /// List of command prefixes considered safe for auto-accept (default: see get_default_safe_commands)
     pub safe_command_prefixes: Option<Vec<String>>,
     /// List of command prefixes that are always denied auto-accept, even if they
@@ -371,6 +384,7 @@ impl Default for Settings {
             last_model: None,
             preferred_mode: AgentMode::Casual,
             ollama_api_key: None,
+            openai_compat_api_key: None,
             sockudo_app_id: None,
             sockudo_app_key: None,
             sockudo_app_secret: None,
@@ -380,6 +394,7 @@ impl Default for Settings {
             show_thinking: false,
             context_limit: None,
             auto_accept_safe_commands: true,
+            skip_health_check: false,
             safe_command_prefixes: None,
             denied_command_prefixes: None,
             project_md_files: None,

--- a/tinyharness-lib/src/provider/llama_cpp.rs
+++ b/tinyharness-lib/src/provider/llama_cpp.rs
@@ -11,8 +11,14 @@ pub struct LlamaCppProvider {
 
 impl LlamaCppProvider {
     pub fn new(base_url: String) -> Self {
+        Self::with_api_key(base_url, None)
+    }
+
+    /// Create a new llama.cpp provider, optionally sending an
+    /// `Authorization: Bearer <api_key>` header on every request.
+    pub fn with_api_key(base_url: String, api_key: Option<String>) -> Self {
         LlamaCppProvider {
-            inner: OpenAiCompatInner::new(base_url),
+            inner: OpenAiCompatInner::with_api_key(base_url, api_key),
         }
     }
 }

--- a/tinyharness-lib/src/provider/mod.rs
+++ b/tinyharness-lib/src/provider/mod.rs
@@ -22,6 +22,13 @@ pub struct ToolDefinition {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
+    /// OpenAI tool call ID (e.g. `call_abc123`). Required by OpenAI-compatible
+    /// servers when echoing the call back in subsequent assistant messages
+    /// and when building matching `tool` result messages. Some servers generate
+    /// it for us; others (or local models) may not, in which case we fall
+    /// back to a synthetic id at serialization time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub function: ToolCallFunction,
 }
 
@@ -89,10 +96,23 @@ pub struct Message {
     pub role: Role,
     pub content: String,
     pub tool_calls: Vec<ToolCall>,
+    /// OpenAI `tool_call_id` for `Role::Tool` messages — links the result back
+    /// to the originating assistant tool call. Required by OpenAI-compatible
+    /// servers. `None` is allowed for round-trips with providers that don't
+    /// use it, but the OpenAI-compatible serialiser will substitute a
+    /// synthetic id when missing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
     /// Optional images attached to the message (multimodal models).
     /// Only meaningful for `User` role messages.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<ImageAttachment>,
+}
+
+impl Default for Message {
+    fn default() -> Self {
+        Message::simple(Role::User, "")
+    }
 }
 
 impl Message {
@@ -102,6 +122,7 @@ impl Message {
             role,
             content: content.into(),
             tool_calls: vec![],
+            tool_call_id: None,
             images: vec![],
         }
     }

--- a/tinyharness-lib/src/provider/ollama.rs
+++ b/tinyharness-lib/src/provider/ollama.rs
@@ -389,6 +389,7 @@ impl OllamaChunk {
                     })
                     .map(|s| s.to_string());
                 ToolCall {
+                    id: None,
                     function: ToolCallFunction {
                         name: tc.function.name,
                         arguments: tc.function.arguments,

--- a/tinyharness-lib/src/provider/openai_compat.rs
+++ b/tinyharness-lib/src/provider/openai_compat.rs
@@ -313,14 +313,28 @@ pub fn to_openai_message(msg: Message) -> OpenAIMessage {
                     .tool_calls
                     .into_iter()
                     .enumerate()
-                    .map(|(i, tc)| OpenAIToolCall {
-                        index: i,
-                        id: String::new(),
-                        call_type: "function".to_string(),
-                        function: OpenAIToolCallFunction {
-                            name: tc.function.name,
-                            arguments: tc.function.arguments.to_string(),
-                        },
+                    .map(|(i, tc)| {
+                        // Synthesize a stable id when the upstream provider
+                        // didn't return one (some local / non-OpenAI servers
+                        // omit it). OpenAI requires a non-empty id.
+                        let id = tc
+                            .id
+                            .filter(|s| !s.is_empty())
+                            .unwrap_or_else(|| format!("call_{}", i));
+                        let args_str = if tc.function.arguments.is_null() {
+                            "{}".to_string()
+                        } else {
+                            tc.function.arguments.to_string()
+                        };
+                        OpenAIToolCall {
+                            index: i,
+                            id,
+                            call_type: "function".to_string(),
+                            function: OpenAIToolCallFunction {
+                                name: tc.function.name,
+                                arguments: args_str,
+                            },
+                        }
                     })
                     .collect();
                 OpenAIMessage {
@@ -331,12 +345,20 @@ pub fn to_openai_message(msg: Message) -> OpenAIMessage {
                 }
             }
         }
-        Role::Tool => OpenAIMessage {
-            role: "tool".to_string(),
-            content: serde_json::Value::String(msg.content),
-            tool_calls: None,
-            tool_call_id: None,
-        },
+        Role::Tool => {
+            // OpenAI requires a non-empty tool_call_id. Fall back to a
+            // deterministic synthetic id when the agent loop didn't set one.
+            let tool_call_id = msg
+                .tool_call_id
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "call_unknown".to_string());
+            OpenAIMessage {
+                role: "tool".to_string(),
+                content: serde_json::Value::String(msg.content),
+                tool_calls: None,
+                tool_call_id: Some(tool_call_id),
+            }
+        }
     }
 }
 
@@ -386,6 +408,27 @@ pub async fn stream_chat_completions(
             return None;
         }
     };
+
+    // If the server returned a non-success status, surface the body as an
+    // error instead of feeding it into the SSE parser (which would silently
+    // drop it).
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let _ = send
+            .send(ChatMessageResponse {
+                message: ChatMessage {
+                    content: format!("Error: HTTP {} — {}", status.as_u16(), body),
+                    tool_calls: vec![],
+                    thinking: None,
+                },
+                done: true,
+                is_error: true,
+                usage: None,
+            })
+            .await;
+        return None;
+    }
 
     let mut stream = response.bytes_stream();
     let mut buf = String::new();
@@ -494,6 +537,7 @@ pub async fn stream_chat_completions(
                 let args: serde_json::Value =
                     serde_json::from_str(&tc.function.arguments).unwrap_or(serde_json::Value::Null);
                 ToolCall {
+                    id: if tc.id.is_empty() { None } else { Some(tc.id) },
                     function: ToolCallFunction {
                         name: tc.function.name,
                         arguments: args,

--- a/tinyharness-lib/src/provider/openai_compat.rs
+++ b/tinyharness-lib/src/provider/openai_compat.rs
@@ -13,16 +13,26 @@ use crate::provider::{
 
 /// Shared inner state for OpenAI-compatible providers (llama.cpp, vLLM, etc.).
 ///
-/// Encapsulates the common `{client, base_url, model}` fields and all shared
-/// logic so that provider implementations only need to differ in `list_models()`.
+/// Encapsulates the common `{client, base_url, model, api_key}` fields and all
+/// shared logic so that provider implementations only need to differ in
+/// `list_models()`.
 pub struct OpenAiCompatInner {
     client: Client,
     base_url: String,
     model: Option<String>,
+    /// Optional bearer token sent as `Authorization: Bearer <key>` on every
+    /// request. Used by hosted OpenAI-compatible APIs (e.g. OpenRouter,
+    /// Together, self-hosted gateways) that require authentication.
+    api_key: Option<String>,
 }
 
 impl OpenAiCompatInner {
     pub fn new(base_url: String) -> Self {
+        Self::with_api_key(base_url, None)
+    }
+
+    /// Create a new inner state with an optional bearer token.
+    pub fn with_api_key(base_url: String, api_key: Option<String>) -> Self {
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(15))
             .read_timeout(Duration::from_secs(300))
@@ -32,6 +42,7 @@ impl OpenAiCompatInner {
             client,
             base_url,
             model: None,
+            api_key,
         }
     }
 
@@ -39,8 +50,13 @@ impl OpenAiCompatInner {
     pub fn health_check(&self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send>> {
         let url = format!("{}/health", self.base_url.trim_end_matches('/'));
         let client = self.client.clone();
+        let api_key = self.api_key.clone();
         Box::pin(async move {
-            match client.get(&url).send().await {
+            let mut req = client.get(&url);
+            if let Some(key) = &api_key {
+                req = req.bearer_auth(key);
+            }
+            match req.send().await {
                 Ok(resp) if resp.status().is_success() => Ok(()),
                 Ok(resp) => Err(format!(
                     "Server returned {}: {}",
@@ -74,8 +90,13 @@ impl OpenAiCompatInner {
         let url = format!("{}/v1/models", self.base_url.trim_end_matches('/'));
         let client = self.client.clone();
         let current_model = self.model.clone();
+        let api_key = self.api_key.clone();
         Box::pin(async move {
-            match client.get(&url).send().await {
+            let mut req = client.get(&url);
+            if let Some(key) = &api_key {
+                req = req.bearer_auth(key);
+            }
+            match req.send().await {
                 Ok(resp) if resp.status().is_success() => {
                     match resp.json::<ModelListResponse>().await {
                         Ok(list) => list.data.into_iter().map(|m| m.id).collect(),
@@ -107,6 +128,7 @@ impl OpenAiCompatInner {
         let openai_tools = tools.into_iter().map(to_openai_tool).collect();
         let client = self.client.clone();
         let chat_url = self.chat_url();
+        let api_key = self.api_key.clone();
 
         let body = ChatRequest {
             model,
@@ -120,7 +142,8 @@ impl OpenAiCompatInner {
 
         // Spawn the streaming work on a background task
         tokio::spawn(async move {
-            let _usage = stream_chat_completions(&client, &chat_url, &body, &send).await;
+            let _usage =
+                stream_chat_completions(&client, &chat_url, &body, api_key.as_deref(), &send).await;
         });
 
         Box::pin(async move { Ok(recv) })
@@ -331,13 +354,21 @@ pub fn to_openai_tool(ti: ToolDefinition) -> OpenAITool {
 /// Stream chat completions from an OpenAI-compatible endpoint.
 /// Returns accumulated tool calls and final content via the sender.
 /// Also returns the token usage if available.
+///
+/// If `api_key` is `Some`, the request includes an
+/// `Authorization: Bearer <key>` header.
 pub async fn stream_chat_completions(
     client: &reqwest::Client,
     url: &str,
     body: &ChatRequest,
+    api_key: Option<&str>,
     send: &tokio::sync::mpsc::Sender<ChatMessageResponse>,
 ) -> Option<crate::provider::TokenUsage> {
-    let response = match client.post(url).json(body).send().await {
+    let mut request = client.post(url).json(body);
+    if let Some(key) = api_key {
+        request = request.bearer_auth(key);
+    }
+    let response = match request.send().await {
         Ok(r) => r,
         Err(e) => {
             let _ = send

--- a/tinyharness-lib/src/provider/sockudo.rs
+++ b/tinyharness-lib/src/provider/sockudo.rs
@@ -1265,6 +1265,7 @@ mod tests {
     fn test_build_ai_input_with_tool_call_messages() {
         let mut msg = Message::simple(Role::Assistant, "I'll list files.");
         msg.tool_calls = vec![ToolCall {
+            id: None,
             function: ToolCallFunction {
                 name: "ls".to_string(),
                 arguments: serde_json::json!({"path": "/"}),

--- a/tinyharness-lib/src/provider/sockudo.rs
+++ b/tinyharness-lib/src/provider/sockudo.rs
@@ -800,6 +800,7 @@ fn parse_tool_calls(value: &serde_json::Value) -> Option<Vec<ToolCall>> {
                 .cloned()
                 .unwrap_or(serde_json::Value::Null);
             Some(ToolCall {
+                id: None,
                 function: ToolCallFunction {
                     name,
                     arguments,

--- a/tinyharness-lib/src/provider/vllm.rs
+++ b/tinyharness-lib/src/provider/vllm.rs
@@ -11,8 +11,14 @@ pub struct VllmProvider {
 
 impl VllmProvider {
     pub fn new(base_url: String) -> Self {
+        Self::with_api_key(base_url, None)
+    }
+
+    /// Create a new vLLM provider, optionally sending an
+    /// `Authorization: Bearer <api_key>` header on every request.
+    pub fn with_api_key(base_url: String, api_key: Option<String>) -> Self {
         VllmProvider {
-            inner: OpenAiCompatInner::new(base_url),
+            inner: OpenAiCompatInner::with_api_key(base_url, api_key),
         }
     }
 }


### PR DESCRIPTION
## Two bugs with hosted OpenAI-compatible gateways

### 1. tool_call_id / id missing → 400 from strict servers

TinyHarness was sending assistant tool calls with `id: ""` and tool result messages with no `tool_call_id` at all. Servers like MiniMax and Xiaomi reject this outright.

**Fix:** Added optional `id` to `ToolCall` and `tool_call_id` to `Message` (both backward-compatible with `#[serde(default)]`). The streaming parser now propagates the upstream id, and `to_openai_message` synthesizes a deterministic fallback (`call_<index>`, `call_unknown`) when the provider doesn't provide one. Null arguments are now sent as `"{}"` instead of being omitted or null.

### 2. Non-2xx responses silently swallowed → spinner forever

Servers returning 400/403/404 were fed into the SSE parser which silently dropped the body. The user saw an infinite "Thinking..." spinner with no error message.

**Fix:** `stream_chat_completions` now checks the HTTP status after `send()`. Non-success responses are surfaced as `Error: HTTP <code> — <body>` immediately, before entering the streaming path.

---

**Tested against:** OpenRouter-style gateway that returns 400 on missing `tool_call_id` (MiniMax, Xiaomi) and nvidia-nim returning DEGRADED function errors — all now surface the actual error to the user.