### PR TITLE
refactor(providers): add dedicated --openai-compat provider, revert l…

### DIFF
--- a/src/agent/setup.rs
+++ b/src/agent/setup.rs
@@ -104,26 +104,30 @@ pub fn prompt_for_api_key(out: &mut Output) -> Result<ApiKeyChoice, String> {
 pub fn prompt_for_provider(out: &mut Output) -> Result<ProviderKind, String> {
     if !std::io::stdin().is_terminal() {
         return Err(
-            "Interactive provider selection requires a TTY. Re-run with --ollama, --llama-cpp, or --vllm, or pass --url.".to_string(),
+            "Interactive provider selection requires a TTY. Re-run with --ollama, --llama-cpp, --vllm, --openai-compat, or --sockudo, or pass --url.".to_string(),
         );
     }
 
     let _ = writeln!(out, "\n{BOLD}Select a provider:{RESET}");
     let _ = writeln!(
         out,
-        "  {CYAN}1{RESET}) ollama    (default: {GRAY}http://127.0.0.1:11434{RESET})"
+        "  {CYAN}1{RESET}) ollama        (default: {GRAY}http://127.0.0.1:11434{RESET})"
     );
     let _ = writeln!(
         out,
-        "  {CYAN}2{RESET}) llama.cpp (default: {GRAY}http://127.0.0.1:8080{RESET})"
+        "  {CYAN}2{RESET}) llama.cpp      (default: {GRAY}http://127.0.0.1:8080{RESET})"
     );
     let _ = writeln!(
         out,
-        "  {CYAN}3{RESET}) vllm      (default: {GRAY}http://127.0.0.1:8000{RESET})"
+        "  {CYAN}3{RESET}) vllm           (default: {GRAY}http://127.0.0.1:8000{RESET})"
     );
     let _ = writeln!(
         out,
-        "  {CYAN}4{RESET}) sockudo   (default: {GRAY}http://127.0.0.1:6001{RESET})"
+        "  {CYAN}4{RESET}) sockudo        (default: {GRAY}http://127.0.0.1:6001{RESET})"
+    );
+    let _ = writeln!(
+        out,
+        "  {CYAN}5{RESET}) openai-compat  (hosted gateway, requires {GRAY}--api-key{RESET})"
     );
 
     loop {
@@ -149,9 +153,12 @@ pub fn prompt_for_provider(out: &mut Output) -> Result<ProviderKind, String> {
         if line == "4" {
             return Ok(ProviderKind::Sockudo);
         }
+        if line == "5" {
+            return Ok(ProviderKind::OpenAiCompat);
+        }
         let _ = writeln!(
             out,
-            "{ORANGE}Please enter 1, 2, 3, or 4 (or press Enter for the default).{RESET}"
+            "{ORANGE}Please enter 1, 2, 3, 4, or 5 (or press Enter for the default).{RESET}"
         );
     }
 }
@@ -172,6 +179,7 @@ pub fn prompt_for_url(
                 ProviderKind::Ollama => "ollama",
                 ProviderKind::LlamaCpp => "llama-cpp",
                 ProviderKind::Vllm => "vllm",
+                ProviderKind::OpenAiCompat => "openai-compat",
                 ProviderKind::Sockudo => "sockudo",
             }
         ));
@@ -221,6 +229,8 @@ pub fn default_url_for(kind: ProviderKind) -> &'static str {
         ProviderKind::Ollama => "http://127.0.0.1:11434",
         ProviderKind::LlamaCpp => "http://127.0.0.1:8080",
         ProviderKind::Vllm => "http://127.0.0.1:8000",
+        // No default — hosted gateways require an explicit URL.
+        ProviderKind::OpenAiCompat => "",
         ProviderKind::Sockudo => "http://127.0.0.1:6001",
     }
 }
@@ -234,21 +244,27 @@ pub fn save_provider_settings(kind: ProviderKind, url: &str) {
     save_settings(&s);
 }
 
-/// Resolve the bearer token for OpenAI-compatible providers using the
+/// Resolve the bearer token for the OpenAI-compatible provider using the
 /// precedence:
 ///
-/// 1. `cli_api_key` (the value of `--api-key` if passed; empty string is
-///    treated as "no key requested" and short-circuits to `None`).
+/// 1. `cli_api_key` — the value of `--api-key` if passed:
+///    - A non-empty value (other than `-`) is used as the key and persisted
+///      to settings so subsequent launches pick it up automatically.
+///    - The sentinel value `"-"` clears any saved key and returns `None`.
+///    - An empty string means the flag was not provided; fall through.
 /// 2. `OPENAI_API_KEY` environment variable, if set and non-empty.
-/// 3. `settings.openai_compat_api_key`, if set.
+/// 3. `settings.openai_compat_api_key`, if set and non-empty.
 ///
-/// When `cli_api_key` is non-empty it is also persisted to settings so that
-/// subsequent launches pick it up automatically without `--api-key`.
-///
-/// Returns `None` when no key should be sent. The Ollama and Sockudo providers
-/// ignore this value entirely.
+/// Returns `None` when no key should be sent. Only the `OpenAiCompat`
+/// provider uses this value; Ollama, llama.cpp, vLLM, and Sockudo ignore it.
 pub fn resolve_api_key(cli_api_key: &str, settings: &Settings) -> Option<String> {
     if !cli_api_key.is_empty() {
+        if cli_api_key == "-" {
+            let mut s = load_settings();
+            s.openai_compat_api_key = None;
+            save_settings(&s);
+            return None;
+        }
         let key = cli_api_key.to_string();
         let mut s = load_settings();
         s.openai_compat_api_key = Some(key.clone());
@@ -446,6 +462,7 @@ mod tests {
             "http://127.0.0.1:8080"
         );
         assert_eq!(default_url_for(ProviderKind::Vllm), "http://127.0.0.1:8000");
+        assert_eq!(default_url_for(ProviderKind::OpenAiCompat), "");
         assert_eq!(
             default_url_for(ProviderKind::Sockudo),
             "http://127.0.0.1:6001"
@@ -491,10 +508,61 @@ mod tests {
             resolve_url(ProviderKind::Vllm, "", &s),
             "http://127.0.0.1:8000"
         );
+        // OpenAiCompat has no default URL — returns empty string, caller
+        // should require --url.
+        assert_eq!(resolve_url(ProviderKind::OpenAiCompat, "", &s), "");
         assert_eq!(
             resolve_url(ProviderKind::Sockudo, "", &s),
             "http://127.0.0.1:6001"
         );
+    }
+
+    #[test]
+    fn resolve_api_key_settings_fallback() {
+        // When no CLI flag and no env var, fall back to settings.
+        let s = Settings {
+            openai_compat_api_key: Some("sk-settings".to_string()),
+            ..Settings::default()
+        };
+        assert_eq!(resolve_api_key("", &s), Some("sk-settings".to_string()));
+    }
+
+    #[test]
+    fn resolve_api_key_empty_settings_returns_none() {
+        let s = Settings::default();
+        assert_eq!(resolve_api_key("", &s), None);
+    }
+
+    #[test]
+    fn resolve_api_key_empty_string_in_settings_is_ignored() {
+        let s = Settings {
+            openai_compat_api_key: Some(String::new()),
+            ..Settings::default()
+        };
+        assert_eq!(resolve_api_key("", &s), None);
+    }
+
+    #[test]
+    fn resolve_api_key_cli_value_wins() {
+        // CLI key takes precedence over env and settings.
+        let s = Settings {
+            openai_compat_api_key: Some("sk-settings".to_string()),
+            ..Settings::default()
+        };
+        assert_eq!(
+            resolve_api_key("sk-from-cli", &s),
+            Some("sk-from-cli".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_api_key_clear_sentinel() {
+        // The sentinel "-" should return None (clear).
+        let s = Settings {
+            openai_compat_api_key: Some("sk-settings".to_string()),
+            ..Settings::default()
+        };
+        assert_eq!(resolve_api_key("-", &s), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use tinyharness_lib::{
     mode::AgentMode,
     provider::{
         Message, Provider, Role, llama_cpp::LlamaCppProvider, ollama::OllamaProvider,
-        sockudo::SockudoProvider, vllm::VllmProvider,
+        openai_compat_provider::OpenAiCompatProvider, sockudo::SockudoProvider, vllm::VllmProvider,
     },
     session::{Session, SessionStore},
     tools::ToolManager,
@@ -47,6 +47,13 @@ struct Args {
     #[arg(short, long)]
     vllm: bool,
 
+    /// Use the generic OpenAI-compatible provider for hosted gateways
+    /// (OpenRouter, Together, custom proxies, etc.) that require a Bearer
+    /// API key. Requires `--api-key` or the `OPENAI_API_KEY` env var, and
+    /// `--url` to specify the gateway endpoint.
+    #[arg(long)]
+    openai_compat: bool,
+
     /// Use the Sockudo provider (AI Transport via Sockudo WebSocket server).
     #[arg(long)]
     sockudo: bool,
@@ -56,10 +63,10 @@ struct Args {
     #[arg(short, long, default_value_t = String::new())]
     url: String,
 
-    /// Bearer token for OpenAI-compatible providers (llama.cpp, vLLM, and any
-    /// server exposing `/v1/chat/completions`). Sent as `Authorization: Bearer
-    /// <key>`. Overrides the saved setting and the `OPENAI_API_KEY` env var.
-    /// Use `--api-key ""` to clear. Has no effect on Ollama or Sockudo.
+    /// Bearer token for the `--openai-compat` provider. Sent as
+    /// `Authorization: Bearer <key>` on every request. Overrides the saved
+    /// setting and the `OPENAI_API_KEY` env var. Use `--api-key -` to clear
+    /// the saved key. Has no effect on Ollama, llama.cpp, vLLM, or Sockudo.
     #[arg(long, default_value_t = String::new())]
     api_key: String,
 
@@ -95,6 +102,8 @@ fn resolve_provider_kind(args: &Args, settings: &Settings) -> ProviderKind {
         ProviderKind::LlamaCpp
     } else if args.vllm {
         ProviderKind::Vllm
+    } else if args.openai_compat {
+        ProviderKind::OpenAiCompat
     } else if args.sockudo {
         ProviderKind::Sockudo
     } else if args.ollama {
@@ -105,18 +114,31 @@ fn resolve_provider_kind(args: &Args, settings: &Settings) -> ProviderKind {
 }
 
 /// Create the provider backend, run health checks, and return it wrapped in Arc<Mutex>.
+#[allow(clippy::too_many_arguments)]
 async fn create_provider(
     kind: ProviderKind,
     url: String,
     api_key: Option<String>,
     skip_health_check: bool,
+    skip_health_check_source: &str,
     settings: &Settings,
 ) -> Arc<Mutex<dyn Provider + Send + Sync>> {
     let provider: Arc<Mutex<dyn Provider + Send + Sync>> = match kind {
-        ProviderKind::LlamaCpp => {
-            Arc::new(Mutex::new(LlamaCppProvider::with_api_key(url, api_key)))
+        ProviderKind::LlamaCpp => Arc::new(Mutex::new(LlamaCppProvider::new(url))),
+        ProviderKind::Vllm => Arc::new(Mutex::new(VllmProvider::new(url))),
+        ProviderKind::OpenAiCompat => {
+            let key = api_key.unwrap_or_else(|| {
+                let mut err_out = Output::stderr();
+                let _ = writeln!(
+                    err_out,
+                    "{BOLD}Error:{RESET} --openai-compat requires an API key. \
+                     Pass {CYAN}--api-key <KEY>{RESET}, set the {CYAN}OPENAI_API_KEY{RESET} \
+                     env var, or configure it via {CYAN}--config{RESET}.",
+                );
+                std::process::exit(1);
+            });
+            Arc::new(Mutex::new(OpenAiCompatProvider::new(url, key)))
         }
-        ProviderKind::Vllm => Arc::new(Mutex::new(VllmProvider::with_api_key(url, api_key))),
         ProviderKind::Ollama => Arc::new(Mutex::new(OllamaProvider::new(
             url,
             settings.ollama_timeout_secs,
@@ -149,7 +171,7 @@ async fn create_provider(
         let mut err_out = Output::stderr();
         let _ = writeln!(
             err_out,
-            "{BOLD}{kind}:{RESET} Skipping health check (--skip-health-check).",
+            "{BOLD}{kind}:{RESET} Skipping health check ({skip_health_check_source}).",
         );
     }
 
@@ -432,7 +454,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let api_key = agent_setup::resolve_api_key(&args.api_key, &settings);
     let skip_hc = args.skip_health_check || settings.skip_health_check;
-    let provider = create_provider(provider_kind, url.clone(), api_key, skip_hc, &settings).await;
+    let skip_hc_source = if args.skip_health_check {
+        "--skip-health-check"
+    } else {
+        "settings.skip_health_check"
+    };
+    let provider = create_provider(
+        provider_kind,
+        url.clone(),
+        api_key,
+        skip_hc,
+        skip_hc_source,
+        &settings,
+    )
+    .await;
 
     // Auto-select model if none is currently set.
     // Sockudo doesn't use a saved model — the worker selects the backend

--- a/tinyharness-lib/src/config/mod.rs
+++ b/tinyharness-lib/src/config/mod.rs
@@ -241,6 +241,12 @@ pub enum ProviderKind {
     Ollama,
     LlamaCpp,
     Vllm,
+    /// Generic OpenAI-compatible provider for hosted gateways (OpenRouter,
+    /// Together, etc.) that require a Bearer API key. Unlike LlamaCpp/Vllm
+    /// which target local unauthenticated servers, this provider always
+    /// sends `Authorization: Bearer <key>` and requires `--api-key` or
+    /// the `OPENAI_API_KEY` env var.
+    OpenAiCompat,
     Sockudo,
 }
 
@@ -250,6 +256,7 @@ impl fmt::Display for ProviderKind {
             ProviderKind::Ollama => f.write_str("ollama"),
             ProviderKind::LlamaCpp => f.write_str("llama.cpp"),
             ProviderKind::Vllm => f.write_str("vllm"),
+            ProviderKind::OpenAiCompat => f.write_str("openai-compat"),
             ProviderKind::Sockudo => f.write_str("sockudo"),
         }
     }
@@ -263,6 +270,7 @@ impl FromStr for ProviderKind {
             "ollama" => Ok(ProviderKind::Ollama),
             "llama.cpp" | "llamacpp" | "llama_cpp" => Ok(ProviderKind::LlamaCpp),
             "vllm" => Ok(ProviderKind::Vllm),
+            "openai-compat" | "openaicompat" | "openai_compat" => Ok(ProviderKind::OpenAiCompat),
             "sockudo" => Ok(ProviderKind::Sockudo),
             _ => Err(format!("Unknown provider '{}'", s)),
         }
@@ -329,10 +337,9 @@ pub struct Settings {
     pub last_model: Option<String>,
     pub preferred_mode: AgentMode,
     pub ollama_api_key: Option<String>,
-    /// API key sent as `Authorization: Bearer <key>` by OpenAI-compatible
-    /// providers (llama.cpp, vLLM, and any server exposing the
-    /// `/v1/chat/completions` endpoint). Set via `--api-key` or
-    /// `OPENAI_API_KEY` env var. Leave `None` for local unauthenticated servers.
+    /// API key sent as `Authorization: Bearer <key>` by the OpenAI-compatible
+    /// provider (`--openai-compat`). Set via `--api-key` or `OPENAI_API_KEY`
+    /// env var. Not used by Ollama, llama.cpp, vLLM, or Sockudo.
     #[serde(default)]
     pub openai_compat_api_key: Option<String>,
     /// Sockudo app ID for the AI Transport provider.
@@ -357,8 +364,8 @@ pub struct Settings {
     /// Automatically accept safe read-only commands in the run tool (default: true)
     pub auto_accept_safe_commands: bool,
     /// Skip the provider health check at startup (default: false).
-    /// Useful for hosted OpenAI-compatible gateways that require a separate
-    /// scope on `/health`, or for self-hosted servers without a `/health`
+    /// Useful for the `--openai-compat` provider when the gateway requires a
+    /// separate scope on `/health`, or for any server without a `/health`
     /// endpoint. When true, the agent proceeds straight to model selection
     /// and reports any connection error on the first real request instead.
     #[serde(default)]

--- a/tinyharness-lib/src/provider/mod.rs
+++ b/tinyharness-lib/src/provider/mod.rs
@@ -1,6 +1,7 @@
 pub mod llama_cpp;
 pub mod ollama;
 pub mod openai_compat;
+pub mod openai_compat_provider;
 pub mod sockudo;
 pub mod vllm;
 

--- a/tinyharness-lib/src/provider/openai_compat_provider.rs
+++ b/tinyharness-lib/src/provider/openai_compat_provider.rs
@@ -5,25 +5,35 @@ use crate::provider::{ChatMessageResponse, Message, Provider, ToolDefinition};
 
 use super::openai_compat::OpenAiCompatInner;
 
-pub struct LlamaCppProvider {
+/// Provider for generic OpenAI-compatible API gateways (OpenRouter, Together,
+/// custom proxies, etc.) that require a Bearer API key.
+///
+/// Unlike `LlamaCppProvider` and `VllmProvider` which target local
+/// unauthenticated servers, this provider always sends an
+/// `Authorization: Bearer <key>` header. The API key is required at
+/// construction time.
+pub struct OpenAiCompatProvider {
     inner: OpenAiCompatInner,
 }
 
-impl LlamaCppProvider {
-    pub fn new(base_url: String) -> Self {
-        LlamaCppProvider {
-            inner: OpenAiCompatInner::new(base_url),
+impl OpenAiCompatProvider {
+    /// Create a new OpenAI-compatible provider with the given base URL and
+    /// API key. The key is sent as `Authorization: Bearer <key>` on every
+    /// request (health check, model list, and chat streaming).
+    pub fn new(base_url: String, api_key: String) -> Self {
+        OpenAiCompatProvider {
+            inner: OpenAiCompatInner::with_api_key(base_url, Some(api_key)),
         }
     }
 }
 
-impl Provider for LlamaCppProvider {
+impl Provider for OpenAiCompatProvider {
     fn health_check(&self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send>> {
         self.inner.health_check()
     }
 
     fn list_models(&self) -> Pin<Box<dyn Future<Output = Vec<String>> + Send>> {
-        Box::pin(async move { vec!["llama-cpp".to_string()] })
+        self.inner.fetch_model_list()
     }
 
     fn select_model(&mut self, name: String) {

--- a/tinyharness-lib/src/provider/vllm.rs
+++ b/tinyharness-lib/src/provider/vllm.rs
@@ -11,14 +11,8 @@ pub struct VllmProvider {
 
 impl VllmProvider {
     pub fn new(base_url: String) -> Self {
-        Self::with_api_key(base_url, None)
-    }
-
-    /// Create a new vLLM provider, optionally sending an
-    /// `Authorization: Bearer <api_key>` header on every request.
-    pub fn with_api_key(base_url: String, api_key: Option<String>) -> Self {
         VllmProvider {
-            inner: OpenAiCompatInner::with_api_key(base_url, api_key),
+            inner: OpenAiCompatInner::new(base_url),
         }
     }
 }


### PR DESCRIPTION
…lama.cpp/vllm to no-auth

Split the OpenAI-compatible API key support into its own provider kind instead of bolting auth onto llama.cpp and vLLM, which target local unauthenticated servers.

Changes:
- New ProviderKind::OpenAiCompat variant with --openai-compat CLI flag
- New OpenAiCompatProvider that wraps OpenAiCompatInner with a required API key (Bearer auth on all requests)
- LlamaCppProvider and VllmProvider reverted to no-auth (plain new())
- --api-key now only applies to --openai-compat (not --llama-cpp/--vllm)
- --api-key "-" sentinel clears the saved key (fixes misleading "" doc)
- skip-health-check message shows actual source (--skip-health-check vs settings.skip_health_check)
- Interactive --config menu now lists openai-compat as option 5
- OpenAiCompat has no default URL (requires explicit --url)
- 5 new unit tests for resolve_api_key precedence + clear sentinel
- 1 new test for default_url_for(OpenAiCompat)
- Updated doc comments throughout to reflect the new architecture

All 89 tests pass, clippy clean, fmt clean.