### PR TITLE
feat: bump to v0.3.0, propagate tool_call_id through signal tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --workspace
+
+  windows-build:
+    name: Build (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --workspace
+
+  windows-test:
+    name: Test (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "TinyHarness"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "tinyharness-lib"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "futures-util",
  "glob",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "tinyharness-ui"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "libc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tinyharness-lib", "tinyharness-ui"]
 
 [package]
 name = "TinyHarness"
-version = "0.2.1"
+version = "0.3.0"
 license = "MIT"
 description = "tinyharness - ai coding harness"
 edition = "2024"
@@ -13,8 +13,8 @@ name = "tinyharness"
 path = "src/main.rs"
 
 [dependencies]
-tinyharness-lib = { version = "0.2.1", path = "tinyharness-lib" }
-tinyharness-ui = { version = "0.2.1", path = "tinyharness-ui" }
+tinyharness-lib = { version = "0.3.0", path = "tinyharness-lib" }
+tinyharness-ui = { version = "0.3.0", path = "tinyharness-ui" }
 clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.52.1", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/src/agent/signal.rs
+++ b/src/agent/signal.rs
@@ -76,6 +76,7 @@ pub async fn handle_signal_event(
     session: &mut Session,
     ctx: &mut CommandContext,
     provider: &std::sync::Arc<Mutex<dyn tinyharness_lib::provider::Provider + Send + Sync>>,
+    tool_call_id: &str,
 ) -> SignalResult {
     match event {
         SignalEvent::SwitchMode { mode } => {
@@ -90,7 +91,7 @@ pub async fn handle_signal_event(
                             old_mode, mode, mode
                         ),
                         tool_calls: vec![],
-                        tool_call_id: None,
+                        tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -105,7 +106,7 @@ pub async fn handle_signal_event(
                         role: Role::Tool,
                         content: format!("Already in '{}' mode. No change was made.", mode),
                         tool_calls: vec![],
-                        tool_call_id: None,
+                        tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -125,7 +126,7 @@ pub async fn handle_signal_event(
             // otherwise return a marker result indicating the caller should
             // handle the question.
             if let Some(error) = validate_question(question, answers) {
-                apply_question_error(error, messages, session);
+                apply_question_error(error, messages, session, tool_call_id);
             }
             // The caller should handle the question before calling this function.
             // This branch should never be reached in practice.
@@ -154,7 +155,7 @@ pub async fn handle_signal_event(
                             }
                         ),
                         tool_calls: vec![],
-                        tool_call_id: None,
+                        tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -172,7 +173,7 @@ pub async fn handle_signal_event(
                             e
                         ),
                         tool_calls: vec![],
-                        tool_call_id: None,
+                        tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -203,7 +204,7 @@ pub async fn handle_signal_event(
                             role: Role::Tool,
                             content: format!("Skill '{}' is already active. Its instructions are already in effect.", name),
                             tool_calls: vec![],
-                            tool_call_id: None,
+                            tool_call_id: Some(tool_call_id.to_string()),
                             images: vec![],
                         });
                         session.append_message(messages.last().expect("just pushed a message"));
@@ -247,7 +248,7 @@ pub async fn handle_signal_event(
                             skill_name, available
                         ),
                         tool_calls: vec![],
-                        tool_call_id: None,
+                        tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
@@ -273,6 +274,7 @@ pub fn apply_question_answer(
     is_skip: bool,
     messages: &mut Vec<Message>,
     session: &mut Session,
+    tool_call_id: &str,
 ) {
     let result_content = if is_skip {
         format!(
@@ -289,7 +291,7 @@ pub fn apply_question_answer(
         role: Role::Tool,
         content: result_content,
         tool_calls: vec![],
-        tool_call_id: None,
+        tool_call_id: Some(tool_call_id.to_string()),
         images: vec![],
     });
     session.append_message(messages.last().expect("just pushed a message"));
@@ -313,12 +315,17 @@ pub fn validate_question(question: &str, answers: &[String]) -> Option<String> {
 }
 
 /// Apply validation error for question signal as a message.
-pub fn apply_question_error(error: String, messages: &mut Vec<Message>, session: &mut Session) {
+pub fn apply_question_error(
+    error: String,
+    messages: &mut Vec<Message>,
+    session: &mut Session,
+    tool_call_id: &str,
+) {
     messages.push(Message {
         role: Role::Tool,
         content: error,
         tool_calls: vec![],
-        tool_call_id: None,
+        tool_call_id: Some(tool_call_id.to_string()),
         images: vec![],
     });
     session.append_message(messages.last().expect("just pushed a message"));
@@ -329,6 +336,7 @@ pub fn apply_signal_parse_error(
     tool_name: &str,
     messages: &mut Vec<Message>,
     session: &mut Session,
+    tool_call_id: &str,
 ) {
     messages.push(Message {
         role: Role::Tool,
@@ -337,7 +345,7 @@ pub fn apply_signal_parse_error(
             tool_name
         ),
         tool_calls: vec![],
-        tool_call_id: None,
+        tool_call_id: Some(tool_call_id.to_string()),
         images: vec![],
     });
     session.append_message(messages.last().expect("just pushed a message"));

--- a/src/agent/tool_result.rs
+++ b/src/agent/tool_result.rs
@@ -4,13 +4,31 @@
 
 use tinyharness_lib::{image::ImageAttachment, provider::Message};
 
+/// Ensure every `ToolCall` in the slice has a non-empty `id`.
+///
+/// Some providers (Ollama, Sockudo) return tool calls without `id`. OpenAI-
+/// compatible APIs require a non-empty id that matches between the assistant
+/// message and the tool result. This function synthesizes stable ids
+/// (`call_0`, `call_1`, …) for any tool calls that are missing one, mutating
+/// the slice in place.
+pub fn ensure_tool_call_ids(tool_calls: &mut [tinyharness_lib::provider::ToolCall]) {
+    for (i, tc) in tool_calls.iter_mut().enumerate() {
+        if tc.id.as_deref().map(|s| s.is_empty()).unwrap_or(true) {
+            tc.id = Some(format!("call_{}", i));
+        }
+    }
+}
+
 /// Result from executing a generic (non-signal) tool call.
 ///
 /// Used by both CLI and TUI agent loops to track tool execution results
 /// before batching them into a single `Role::Tool` message.
 pub struct GenericToolResult {
-    /// Formatted content for batching into the conversation message.
+    /// Formatted content for the conversation message.
     pub content: String,
+    /// The `tool_call_id` from the originating assistant tool call.
+    /// OpenAI-compatible APIs require this to match the assistant's tool call id.
+    pub tool_call_id: String,
     /// If this was an auditable tool (run/write/edit), the tool name.
     pub audit_tool_name: Option<String>,
     /// For auditable tools: the primary argument (command for "run", path for "write"/"edit").
@@ -23,44 +41,30 @@ pub struct GenericToolResult {
     pub images: Vec<ImageAttachment>,
 }
 
-/// Batch multiple generic tool results into a single `Role::Tool` message.
+/// Convert tool results into individual `Role::Tool` messages, one per result.
 ///
-/// For a single result, the content is used directly. For multiple results,
-/// they're joined with separators and a count header.
+/// OpenAI-compatible APIs require one `Role::Tool` message per tool call, each
+/// with a `tool_call_id` matching the originating assistant tool call.
 ///
-/// Returns `None` if the results list is empty.
-pub fn batch_tool_results(results: Vec<GenericToolResult>) -> Option<Message> {
-    if results.is_empty() {
-        return None;
-    }
-
-    let batched_content = if results.len() == 1 {
-        results[0].content.clone()
-    } else {
-        format!(
-            "Multiple tool results ({} total):\n\n{}",
-            results.len(),
-            results
-                .iter()
-                .map(|r| r.content.as_str())
-                .collect::<Vec<_>>()
-                .join("\n\n---\n\n")
-        )
-    };
-
-    // Collect images from all tool results
-    let all_images: Vec<ImageAttachment> = results.into_iter().flat_map(|r| r.images).collect();
-
-    Some(Message {
-        role: tinyharness_lib::provider::Role::Tool,
-        content: format!(
-            "Tool results:\n{}\n\nUse these results to continue helping the user.",
-            batched_content
-        ),
-        tool_calls: vec![],
-        tool_call_id: None,
-        images: all_images,
-    })
+/// Returns an empty vector if the results list is empty.
+pub fn batch_tool_results(results: Vec<GenericToolResult>) -> Vec<Message> {
+    results
+        .into_iter()
+        .map(|r| {
+            // Collect images from this tool result
+            let images = r.images;
+            Message {
+                role: tinyharness_lib::provider::Role::Tool,
+                content: format!(
+                    "Tool results:\n{}\n\nUse these results to continue helping the user.",
+                    r.content
+                ),
+                tool_calls: vec![],
+                tool_call_id: Some(r.tool_call_id),
+                images,
+            }
+        })
+        .collect()
 }
 
 /// Build audit detail for a tool call.

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -18,7 +18,8 @@ use tinyharness_ui::ui::confirm::Confirmation;
 use super::confirm::ConfirmationDecision;
 use super::signal::{self, SignalResult};
 use super::tool_result::{
-    GenericToolResult, audit_info_for_tool, batch_tool_results, log_tool_audit,
+    GenericToolResult, audit_info_for_tool, batch_tool_results, ensure_tool_call_ids,
+    log_tool_audit,
 };
 
 /// Handle tool calls from the assistant response.
@@ -42,6 +43,14 @@ pub async fn handle_tool_calls<W: Write>(
         return Ok(false);
     }
 
+    // Ensure every tool call has a non-empty id (some providers omit them).
+    // We clone so we can mutate, and use the cloned slice for the rest of the
+    // function so tool_call_ids are consistent between assistant message and
+    // tool result messages.
+    let mut tool_calls: Vec<ToolCall> = tool_calls.to_vec();
+    ensure_tool_call_ids(&mut tool_calls);
+    let tool_calls = tool_calls; // immutable from here
+
     let tool_count = tool_calls.len();
     writeln!(
         stdout,
@@ -52,7 +61,7 @@ pub async fn handle_tool_calls<W: Write>(
     messages.push(Message {
         role: Role::Assistant,
         content: response_content.to_string(),
-        tool_calls: tool_calls.to_vec(),
+        tool_calls: tool_calls.clone(),
         tool_call_id: None,
         images: vec![],
     });
@@ -81,21 +90,24 @@ pub async fn handle_tool_calls<W: Write>(
             if let Some(event) =
                 tool_manager.parse_signal_event(&call.function.name, &call.function.arguments)
             {
+                let tc_id = call.id.as_deref().unwrap_or("");
                 // Question signal requires user interaction — handle it directly
                 // since the shared signal module can't do CLI I/O.
                 match &event {
                     SignalEvent::Question { question, answers } => {
-                        handle_question_cli(question, answers, messages, session, stdout)?;
+                        handle_question_cli(question, answers, messages, session, stdout, tc_id)?;
                     }
                     _ => {
-                        let result =
-                            signal::handle_signal_event(&event, messages, session, ctx, &provider)
-                                .await;
+                        let result = signal::handle_signal_event(
+                            &event, messages, session, ctx, &provider, tc_id,
+                        )
+                        .await;
                         render_signal_result_cli(&result, stdout)?;
                     }
                 }
             } else {
-                signal::apply_signal_parse_error(&call.function.name, messages, session);
+                let tc_id = call.id.as_deref().unwrap_or("");
+                signal::apply_signal_parse_error(&call.function.name, messages, session, tc_id);
             }
             continue;
         }
@@ -110,7 +122,7 @@ pub async fn handle_tool_calls<W: Write>(
 
         // Confirmation step using shared decision logic
         let decision = super::confirm::decide_tool_confirmation(
-            call,
+            &call,
             *auto_accept,
             auto_accept_safe_commands,
             &safe_commands,
@@ -121,7 +133,7 @@ pub async fn handle_tool_calls<W: Write>(
         let (approved, auto_accepted) = match decision {
             ConfirmationDecision::AutoApproved { auto_accepted: aa } => (true, aa),
             ConfirmationDecision::NeedsConfirmation => {
-                match tinyharness_ui::ui::confirm::prompt_tool_confirmation(stdout, call)? {
+                match tinyharness_ui::ui::confirm::prompt_tool_confirmation(stdout, &call)? {
                     Confirmation::No => {
                         stdout.write_all(
                             format!("  {}Skipped{}{}\n", ORANGE, RESET, BOLD).as_bytes(),
@@ -147,12 +159,12 @@ pub async fn handle_tool_calls<W: Write>(
         if !approved {
             let args_summary = super::display::format_args_summary(&call.function.arguments);
             messages.push(Message {
-                role: Role::User,
+                role: Role::Tool,
                 content: format!(
                     "[Tool denied] The user denied the '{}' tool call with arguments: {}\n\nTell the user you cannot proceed with that action unless they approve it.",
                     call.function.name, args_summary
                 ),
-                tool_call_id: None,
+                tool_call_id: call.id.clone(),
                 tool_calls: vec![], images: vec![],
             });
             session.append_message(messages.last().expect("just pushed a message"));
@@ -160,22 +172,26 @@ pub async fn handle_tool_calls<W: Write>(
         }
 
         // Generic tool execution — collect result for batching
-        let result = execute_generic_tool(call, tool_manager, stdout, auto_accepted).await;
+        let result = execute_generic_tool(&call, tool_manager, stdout, auto_accepted).await;
 
         // Log to audit if this was an auditable tool (run/write/edit)
         log_tool_audit(
             session.id(),
-            call,
+            &call,
             auto_accepted,
             result.duration_ms,
             result.is_error,
         );
 
-        generic_tool_results.push(result);
+        generic_tool_results.push(GenericToolResult {
+            tool_call_id: call.id.clone().unwrap_or_default(),
+            ..result
+        });
     }
 
-    // Batch all generic tool results into a single message
-    if let Some(msg) = batch_tool_results(generic_tool_results) {
+    // Push individual tool result messages (one per tool call)
+    let tool_msgs = batch_tool_results(generic_tool_results);
+    for msg in tool_msgs {
         messages.push(msg);
         session.append_message(messages.last().expect("just pushed a message"));
     }
@@ -190,10 +206,11 @@ fn handle_question_cli<W: Write>(
     messages: &mut Vec<Message>,
     session: &mut Session,
     stdout: &mut W,
+    tool_call_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Validate
     if let Some(error) = signal::validate_question(question, answers) {
-        signal::apply_question_error(error, messages, session);
+        signal::apply_question_error(error, messages, session, tool_call_id);
         return Ok(());
     }
 
@@ -271,7 +288,14 @@ fn handle_question_cli<W: Write>(
     }
     stdout.flush()?;
 
-    signal::apply_question_answer(question, &selected_answer, is_skip, messages, session);
+    signal::apply_question_answer(
+        question,
+        &selected_answer,
+        is_skip,
+        messages,
+        session,
+        tool_call_id,
+    );
     Ok(())
 }
 
@@ -585,6 +609,7 @@ async fn execute_generic_tool<W: Write>(
 
     GenericToolResult {
         content: format!("### {} Tool Result\n\n{}", call.function.name, result),
+        tool_call_id: String::new(), // set by caller
         audit_tool_name,
         audit_detail,
         duration_ms,

--- a/src/agent/tui_loop.rs
+++ b/src/agent/tui_loop.rs
@@ -35,8 +35,8 @@ use super::confirm::ConfirmationDecision;
 use super::display::format_args_summary_tui;
 use super::signal::{self, SignalResult};
 use super::tool_result::{
-    GenericToolResult, audit_info_for_tool, batch_tool_results, compute_tool_diff, log_tool_audit,
-    tool_display_content,
+    GenericToolResult, audit_info_for_tool, batch_tool_results, compute_tool_diff,
+    ensure_tool_call_ids, log_tool_audit, tool_display_content,
 };
 
 /// Strip common ANSI SGR escape sequences from a string.
@@ -598,6 +598,10 @@ async fn process_user_message(
 
         // Handle tool calls
         if !tool_calls.is_empty() {
+            // Ensure every tool call has a non-empty id (some providers omit them)
+            let mut tool_calls = tool_calls;
+            ensure_tool_call_ids(&mut tool_calls);
+
             // Push the assistant message with tool calls
             messages.push(Message {
                 role: Role::Assistant,
@@ -699,9 +703,10 @@ async fn handle_tui_tool_calls(
                 // Question signal requires user interaction — handle via TUI channel
                 match &event {
                     SignalEvent::Question { question, answers } => {
+                        let tc_id = call.id.as_deref().unwrap_or("");
                         // Validate question
                         if let Some(error) = signal::validate_question(question, answers) {
-                            signal::apply_question_error(error, messages, session);
+                            signal::apply_question_error(error, messages, session, tc_id);
                             continue;
                         }
 
@@ -738,10 +743,11 @@ async fn handle_tui_tool_calls(
 
                         let is_skip = answer.starts_with("Skipped");
                         signal::apply_question_answer(
-                            question, &answer, is_skip, messages, session,
+                            question, &answer, is_skip, messages, session, tc_id,
                         );
                     }
                     _ => {
+                        let tc_id = call.id.as_deref().unwrap_or("");
                         // Swap ctx.output with a capture writer so that any
                         // output produced by the signal handler (e.g.
                         // auto_compact's compaction progress) is captured
@@ -751,9 +757,10 @@ async fn handle_tui_tool_calls(
                         let captured_output = Output::new(Box::new(capture.clone()));
                         let original_output = std::mem::replace(&mut ctx.output, captured_output);
 
-                        let result =
-                            signal::handle_signal_event(&event, messages, session, ctx, provider)
-                                .await;
+                        let result = signal::handle_signal_event(
+                            &event, messages, session, ctx, provider, tc_id,
+                        )
+                        .await;
 
                         // Restore the original output writer
                         ctx.output = original_output;
@@ -788,7 +795,8 @@ async fn handle_tui_tool_calls(
                     }
                 }
             } else {
-                signal::apply_signal_parse_error(&call.function.name, messages, session);
+                let tc_id = call.id.as_deref().unwrap_or("");
+                signal::apply_signal_parse_error(&call.function.name, messages, session, tc_id);
             }
             continue;
         }
@@ -856,13 +864,13 @@ async fn handle_tui_tool_calls(
             let args_summary =
                 format_args_summary_tui(&call.function.name, &call.function.arguments);
             messages.push(Message {
-                role: Role::System,
+                role: Role::Tool,
                 content: format!(
                     "The user denied the '{}' tool call with arguments: {}",
                     call.function.name, args_summary
                 ),
                 tool_calls: vec![],
-                tool_call_id: None,
+                tool_call_id: call.id.clone(),
                 images: vec![],
             });
             session.append_message(messages.last().expect("just pushed a message"));
@@ -905,6 +913,7 @@ async fn handle_tui_tool_calls(
         let (audit_tool_name, audit_detail) = audit_info_for_tool(call);
         generic_tool_results.push(GenericToolResult {
             content: format!("### {} Tool Result\n\n{}", call.function.name, result),
+            tool_call_id: call.id.clone().unwrap_or_default(),
             audit_tool_name,
             audit_detail,
             duration_ms,
@@ -913,8 +922,9 @@ async fn handle_tui_tool_calls(
         });
     }
 
-    // Batch all generic tool results into a single message
-    if let Some(msg) = batch_tool_results(generic_tool_results) {
+    // Push individual tool result messages (one per tool call)
+    let tool_msgs = batch_tool_results(generic_tool_results);
+    for msg in tool_msgs {
         messages.push(msg);
         session.append_message(messages.last().expect("just pushed a message"));
     }

--- a/tinyharness-lib/Cargo.toml
+++ b/tinyharness-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyharness-lib"
-version = "0.2.1"
+version = "0.3.0"
 license = "MIT"
 description = "core liblary for tinyharness"
 edition = "2024"

--- a/tinyharness-lib/src/provider/ollama.rs
+++ b/tinyharness-lib/src/provider/ollama.rs
@@ -451,8 +451,10 @@ async fn stream_ollama_chat(
             serde_json::Value::Array(arr) => {
                 // Fix 2: Add "name" field to tool result messages by tracking
                 // tool_calls from the most recent assistant message.
+                // Also inject "tool_call_id" for OpenAI-compatible backends.
                 // Fix 3: Re-inject thought_signatures into assistant tool_calls.
                 let mut prev_tool_names: Vec<String> = Vec::new();
+                let mut prev_tool_ids: Vec<String> = Vec::new();
                 let mut ts_idx: usize = 0;
                 for msg in arr.iter_mut() {
                     if let serde_json::Value::Object(msg_map) = msg {
@@ -460,6 +462,7 @@ async fn stream_ollama_chat(
                         match role {
                             "assistant" => {
                                 prev_tool_names.clear();
+                                prev_tool_ids.clear();
                                 if let Some(tcs) = msg_map.get_mut("tool_calls")
                                     && let Some(tc_arr) = tcs.as_array_mut()
                                 {
@@ -479,8 +482,8 @@ async fn stream_ollama_chat(
                                     }
                                     ts_idx += 1;
 
-                                    // Track tool names for Fix 2
-                                    for tc in tc_arr.iter() {
+                                    // Track tool names and ids for Fix 2
+                                    for (i, tc) in tc_arr.iter().enumerate() {
                                         if let Some(name) = tc
                                             .get("function")
                                             .and_then(|f| f.get("name"))
@@ -488,18 +491,36 @@ async fn stream_ollama_chat(
                                         {
                                             prev_tool_names.push(name.to_string());
                                         }
+                                        // Track tool call ids (synthesize if missing)
+                                        let id = tc
+                                            .get("id")
+                                            .and_then(|v| v.as_str())
+                                            .filter(|s| !s.is_empty())
+                                            .map(|s| s.to_string())
+                                            .unwrap_or_else(|| format!("call_{}", i));
+                                        prev_tool_ids.push(id);
                                     }
                                 } else {
                                     ts_idx += 1;
                                 }
                             }
-                            "tool"
-                                if !msg_map.contains_key("name") && prev_tool_names.len() == 1 =>
-                            {
-                                msg_map.insert(
-                                    "name".to_string(),
-                                    serde_json::Value::String(prev_tool_names[0].clone()),
-                                );
+                            "tool" => {
+                                // Add "name" field for Ollama/Gemini compatibility
+                                // (only when there's exactly one tool call)
+                                if !msg_map.contains_key("name") && prev_tool_names.len() == 1 {
+                                    msg_map.insert(
+                                        "name".to_string(),
+                                        serde_json::Value::String(prev_tool_names[0].clone()),
+                                    );
+                                }
+                                // Add "tool_call_id" for OpenAI-compatible backends
+                                if !msg_map.contains_key("tool_call_id") && prev_tool_ids.len() == 1
+                                {
+                                    msg_map.insert(
+                                        "tool_call_id".to_string(),
+                                        serde_json::Value::String(prev_tool_ids[0].clone()),
+                                    );
+                                }
                             }
                             _ => {}
                         }

--- a/tinyharness-lib/src/provider/openai_compat.rs
+++ b/tinyharness-lib/src/provider/openai_compat.rs
@@ -346,17 +346,15 @@ pub fn to_openai_message(msg: Message) -> OpenAIMessage {
             }
         }
         Role::Tool => {
-            // OpenAI requires a non-empty tool_call_id. Fall back to a
-            // deterministic synthetic id when the agent loop didn't set one.
-            let tool_call_id = msg
-                .tool_call_id
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| "call_unknown".to_string());
+            // tool_call_id should have been set by the agent loop. If somehow
+            // missing, skip the field rather than emitting a bogus id that the
+            // server will reject.
+            let tool_call_id = msg.tool_call_id.filter(|s| !s.is_empty());
             OpenAIMessage {
                 role: "tool".to_string(),
                 content: serde_json::Value::String(msg.content),
                 tool_calls: None,
-                tool_call_id: Some(tool_call_id),
+                tool_call_id,
             }
         }
     }

--- a/tinyharness-lib/src/provider/sockudo.rs
+++ b/tinyharness-lib/src/provider/sockudo.rs
@@ -743,8 +743,13 @@ fn build_ai_input_opt(
                         .iter()
                         .enumerate()
                         .map(|(i, tc)| {
+                            let id = tc
+                                .id
+                                .clone()
+                                .filter(|s| !s.is_empty())
+                                .unwrap_or_else(|| format!("call-{}", i));
                             serde_json::json!({
-                                "id": format!("call-{}", i),
+                                "id": id,
                                 "type": "function",
                                 "function": {
                                     "name": tc.function.name,
@@ -754,6 +759,13 @@ fn build_ai_input_opt(
                         })
                         .collect::<Vec<_>>()
                 );
+            }
+            // Tool messages must include tool_call_id matching the assistant's tool call
+            if m.role == Role::Tool
+                && let Some(tcid) = &m.tool_call_id
+                && !tcid.is_empty()
+            {
+                obj["tool_call_id"] = serde_json::Value::String(tcid.clone());
             }
             obj
         })
@@ -1265,18 +1277,16 @@ mod tests {
     fn test_build_ai_input_with_tool_call_messages() {
         let mut msg = Message::simple(Role::Assistant, "I'll list files.");
         msg.tool_calls = vec![ToolCall {
-            id: None,
+            id: Some("call-42".to_string()),
             function: ToolCallFunction {
                 name: "ls".to_string(),
                 arguments: serde_json::json!({"path": "/"}),
                 thought_signature: None,
             },
         }];
-        let messages = vec![
-            Message::simple(Role::User, "List /"),
-            msg,
-            Message::simple(Role::Tool, "file1\nfile2"),
-        ];
+        let mut tool_msg = Message::simple(Role::Tool, "file1\nfile2");
+        tool_msg.tool_call_id = Some("call-42".to_string());
+        let messages = vec![Message::simple(Role::User, "List /"), msg, tool_msg];
         let result = build_ai_input("m", &messages, &[]);
         assert_eq!(result["messages"].as_array().unwrap().len(), 3);
         assert_eq!(result["messages"][1]["role"], "assistant");
@@ -1284,9 +1294,11 @@ mod tests {
         // Tool calls must include id and type fields for OpenAI-compatible backends
         let tc = &result["messages"][1]["tool_calls"][0];
         assert_eq!(tc["type"], "function");
-        assert!(tc["id"].as_str().unwrap().starts_with("call-"));
+        assert_eq!(tc["id"], "call-42");
         assert_eq!(tc["function"]["name"], "ls");
         assert_eq!(result["messages"][2]["role"], "tool");
+        // Tool messages must include tool_call_id matching the assistant's tool call
+        assert_eq!(result["messages"][2]["tool_call_id"], "call-42");
     }
 
     #[test]

--- a/tinyharness-ui/Cargo.toml
+++ b/tinyharness-ui/Cargo.toml
@@ -10,9 +10,11 @@ tinyharness-lib = { version = "0.3.0", path = "../tinyharness-lib" }
 rustyline = { version = "18.0.0", features = ["derive"] }
 serde_json = "1.0.149"
 regex = "1.11.1"
+unicode-width = "0.2"
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 signal-hook = "0.4"
-unicode-width = "0.2"
 
 [features]
 default = []

--- a/tinyharness-ui/Cargo.toml
+++ b/tinyharness-ui/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "tinyharness-ui"
-version = "0.2.1"
+version = "0.3.0"
 license = "MIT"
 description = "ui library for tinyharness"
 edition = "2024"
 
 [dependencies]
-tinyharness-lib = { version = "0.2.1", path = "../tinyharness-lib" }
+tinyharness-lib = { version = "0.3.0", path = "../tinyharness-lib" }
 rustyline = { version = "18.0.0", features = ["derive"] }
 serde_json = "1.0.149"
 regex = "1.11.1"

--- a/tinyharness-ui/src/tui/app.rs
+++ b/tinyharness-ui/src/tui/app.rs
@@ -14,7 +14,7 @@ use super::cell::{Cell, Style};
 use super::event::{Event, EventParser, Key, KeyEvent, MouseButton, MouseEvent};
 use super::layout::{Constraint, Direction, Layout, Rect};
 use super::screen::Screen;
-use super::terminal::{Size, Terminal};
+use super::terminal::Terminal;
 use super::widget::{Action, Widget};
 use super::widgets::conversation::{ContextWarningLevel, ConversationLine, ConversationWidget};
 use super::widgets::input_bar::InputBarWidget;
@@ -1573,6 +1573,7 @@ pub fn spawn_stdin_reader() -> (mpsc::Sender<Event>, mpsc::Receiver<Event>) {
     std::thread::spawn(move || {
         #[cfg(unix)]
         {
+            use super::terminal::Size;
             use std::sync::atomic::{AtomicBool, Ordering as SignalOrdering};
 
             let resize_flag = std::sync::Arc::new(AtomicBool::new(false));

--- a/tinyharness-ui/src/tui/terminal.rs
+++ b/tinyharness-ui/src/tui/terminal.rs
@@ -1,10 +1,100 @@
 // ── Terminal control primitives ─────────────────────────────────────────────
 //
 // Raw mode, alternate screen buffer, cursor control, and terminal size
-// detection — all using raw ANSI sequences and POSIX termios.
+// detection — all using raw ANSI sequences and platform-specific APIs.
 // No external TUI framework dependency.
 
 use std::io::{self, Write};
+
+// ── Windows Console API FFI ─────────────────────────────────────────────────
+
+#[cfg(windows)]
+mod winapi {
+    use std::ffi::c_void;
+    use std::io;
+
+    pub type Bool = i32;
+    pub type DWORD = u32;
+    pub type HANDLE = *mut c_void;
+
+    pub const STD_INPUT_HANDLE: DWORD = 0xFFFFFFF6; // (DWORD)-10
+    pub const STD_OUTPUT_HANDLE: DWORD = 0xFFFFFFF5; // (DWORD)-11
+
+    pub const ENABLE_ECHO_INPUT: DWORD = 0x0004;
+    pub const ENABLE_LINE_INPUT: DWORD = 0x0002;
+    pub const ENABLE_PROCESSED_INPUT: DWORD = 0x0001;
+    pub const ENABLE_VIRTUAL_TERMINAL_INPUT: DWORD = 0x0200;
+    pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: DWORD = 0x0004;
+
+    #[allow(non_snake_case)]
+    #[repr(C)]
+    pub struct CONSOLE_SCREEN_BUFFER_INFO {
+        pub dwSize: COORD,
+        pub dwCursorPosition: COORD,
+        pub wAttributes: u16,
+        pub srWindow: SMALL_RECT,
+        pub dwMaximumWindowSize: COORD,
+    }
+
+    #[allow(non_snake_case)]
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    pub struct COORD {
+        pub X: i16,
+        pub Y: i16,
+    }
+
+    #[allow(non_snake_case)]
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    pub struct SMALL_RECT {
+        pub Left: i16,
+        pub Top: i16,
+        pub Right: i16,
+        pub Bottom: i16,
+    }
+
+    unsafe extern "system" {
+        pub fn GetStdHandle(nStdHandle: DWORD) -> HANDLE;
+        pub fn GetConsoleMode(hConsoleHandle: HANDLE, lpMode: *mut DWORD) -> Bool;
+        pub fn SetConsoleMode(hConsoleHandle: HANDLE, dwMode: DWORD) -> Bool;
+        pub fn GetConsoleScreenBufferInfo(
+            hConsoleOutput: HANDLE,
+            lpConsoleScreenBufferInfo: *mut CONSOLE_SCREEN_BUFFER_INFO,
+        ) -> Bool;
+    }
+
+    /// Get the console mode for the given standard handle.
+    pub fn get_console_mode(handle: HANDLE) -> io::Result<DWORD> {
+        let mut mode: DWORD = 0;
+        unsafe {
+            if GetConsoleMode(handle, &mut mode) == 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(mode)
+    }
+
+    /// Set the console mode for the given standard handle.
+    pub fn set_console_mode(handle: HANDLE, mode: DWORD) -> io::Result<()> {
+        unsafe {
+            if SetConsoleMode(handle, mode) == 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(())
+    }
+
+    /// Get the stdin handle.
+    pub fn stdin_handle() -> HANDLE {
+        unsafe { GetStdHandle(STD_INPUT_HANDLE) }
+    }
+
+    /// Get the stdout handle.
+    pub fn stdout_handle() -> HANDLE {
+        unsafe { GetStdHandle(STD_OUTPUT_HANDLE) }
+    }
+}
 
 // ── Terminal size ────────────────────────────────────────────────────────────
 
@@ -20,7 +110,9 @@ impl Size {
         Self { cols, rows }
     }
 
-    /// Get the terminal size from the TIOCGWINSZ ioctl (Unix).
+    /// Get the terminal size from the OS.
+    ///
+    /// On Unix, uses TIOCGWINSZ ioctl. On Windows, uses the Console API.
     #[cfg(unix)]
     pub fn from_terminal() -> io::Result<Self> {
         // Safety: TIOCGWINSZ is a read-only ioctl that doesn't modify memory.
@@ -46,6 +138,35 @@ impl Size {
         })
     }
 
+    /// Get the terminal size from the Windows Console API.
+    #[cfg(windows)]
+    pub fn from_terminal() -> io::Result<Self> {
+        use self::winapi::*;
+        let handle = stdout_handle();
+        if handle.is_null() {
+            return Err(io::Error::new(io::ErrorKind::Other, "GetStdHandle failed"));
+        }
+        let mut info: CONSOLE_SCREEN_BUFFER_INFO = unsafe { std::mem::zeroed() };
+        unsafe {
+            if GetConsoleScreenBufferInfo(handle, &mut info) == 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(Size {
+            cols: (info.srWindow.Right - info.srWindow.Left + 1) as u16,
+            rows: (info.srWindow.Bottom - info.srWindow.Top + 1) as u16,
+        })
+    }
+
+    /// Fallback for platforms without a native terminal size API.
+    #[cfg(not(any(unix, windows)))]
+    pub fn from_terminal() -> io::Result<Self> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "terminal size detection not supported on this platform",
+        ))
+    }
+
     /// Fallback: use environment variables COLUMNS and LINES.
     pub fn from_env() -> Option<Self> {
         let cols = std::env::var("COLUMNS")
@@ -65,10 +186,16 @@ impl Size {
 
 // ── Raw mode control ────────────────────────────────────────────────────────
 
-/// Saved terminal state for restoration on exit.
+/// Saved terminal state for restoration on exit (Unix).
 #[cfg(unix)]
 struct SavedTermios {
     original: libc::termios,
+}
+
+/// Saved console mode for restoration on exit (Windows).
+#[cfg(windows)]
+struct SavedConsoleMode {
+    stdin_mode: u32,
 }
 
 /// Manages raw terminal mode and alternate screen buffer.
@@ -85,6 +212,8 @@ pub struct Terminal<W: Write> {
     size: Size,
     #[cfg(unix)]
     saved_termios: Option<SavedTermios>,
+    #[cfg(windows)]
+    saved_console_mode: Option<SavedConsoleMode>,
     in_raw_mode: bool,
     in_alternate_screen: bool,
     cursor_hidden: bool,
@@ -102,6 +231,8 @@ impl<W: Write> Terminal<W> {
             size,
             #[cfg(unix)]
             saved_termios: None,
+            #[cfg(windows)]
+            saved_console_mode: None,
             in_raw_mode: false,
             in_alternate_screen: false,
             cursor_hidden: false,
@@ -167,7 +298,7 @@ impl<W: Write> Terminal<W> {
         Ok(())
     }
 
-    /// Restore the terminal to its original settings.
+    /// Restore the terminal to its original settings (Unix).
     #[cfg(unix)]
     pub fn leave_raw_mode(&mut self) -> io::Result<()> {
         if !self.in_raw_mode {
@@ -183,6 +314,84 @@ impl<W: Write> Terminal<W> {
         }
 
         self.in_raw_mode = false;
+        Ok(())
+    }
+
+    /// Switch the terminal to raw mode on Windows.
+    ///
+    /// Disables line input and echo on the console input handle, and
+    /// enables virtual terminal processing on the output handle so that
+    /// ANSI escape sequences are interpreted by the console.
+    #[cfg(windows)]
+    pub fn enter_raw_mode(&mut self) -> io::Result<()> {
+        if self.in_raw_mode {
+            return Ok(());
+        }
+
+        use self::winapi::*;
+
+        let stdin = stdin_handle();
+        if stdin.is_null() {
+            return Err(io::Error::new(io::ErrorKind::Other, "GetStdHandle failed"));
+        }
+
+        // Save original stdin mode
+        let original_mode = winapi::get_console_mode(stdin)?;
+        self.saved_console_mode = Some(SavedConsoleMode {
+            stdin_mode: original_mode,
+        });
+
+        // Disable echo and line input; enable virtual terminal input
+        let new_mode =
+            original_mode & !(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
+        let new_mode = new_mode | ENABLE_VIRTUAL_TERMINAL_INPUT;
+        winapi::set_console_mode(stdin, new_mode)?;
+
+        // Also enable VT processing on stdout so ANSI escape sequences work
+        let stdout = stdout_handle();
+        if !stdout.is_null() {
+            if let Ok(out_mode) = winapi::get_console_mode(stdout) {
+                let _ =
+                    winapi::set_console_mode(stdout, out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+            }
+        }
+
+        self.in_raw_mode = true;
+        Ok(())
+    }
+
+    /// Restore the terminal to its original settings (Windows).
+    #[cfg(windows)]
+    pub fn leave_raw_mode(&mut self) -> io::Result<()> {
+        if !self.in_raw_mode {
+            return Ok(());
+        }
+
+        use self::winapi::*;
+
+        if let Some(saved) = &self.saved_console_mode {
+            let stdin = stdin_handle();
+            if !stdin.is_null() {
+                let _ = winapi::set_console_mode(stdin, saved.stdin_mode);
+            }
+        }
+
+        self.in_raw_mode = false;
+        Ok(())
+    }
+
+    /// Raw mode is not supported on other platforms.
+    #[cfg(not(any(unix, windows)))]
+    pub fn enter_raw_mode(&mut self) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "raw mode not supported on this platform",
+        ))
+    }
+
+    /// No-op restore on platforms without raw mode support.
+    #[cfg(not(any(unix, windows)))]
+    pub fn leave_raw_mode(&mut self) -> io::Result<()> {
         Ok(())
     }
 
@@ -346,10 +555,7 @@ impl<W: Write> Drop for Terminal<W> {
         let _ = self.disable_bracketed_paste();
         let _ = self.show_cursor();
         let _ = self.leave_alternate_screen();
-        #[cfg(unix)]
-        {
-            let _ = self.leave_raw_mode();
-        }
+        let _ = self.leave_raw_mode();
     }
 }
 


### PR DESCRIPTION
- Bump version to 0.3.0 across all workspace crates
- Pass tool_call_id to handle_signal_event and include it in all signal tool result messages (switch_mode, question, auto_compact, invoke_skill, screenshot)
- Update tool result formatting and display in agent loop
- Refactor provider internals (ollama, openai_compat, sockudo)
- Update TUI loop to pass tool_call_id through signal dispatch