### PR TITLE
docs: update for v0.3.0 — openai-compat provider, tool_call_id, Windo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lightweight AI assistant framework in Rust with pluggable LLM providers (Ollama,
 
 ## Features
 
-- **Pluggable Providers**: Ollama, llama.cpp, vLLM, and any OpenAI-compatible API. Swap backends without changing application code. Ollama supports retries with backoff, configurable timeouts, and reasoning/think levels. ⚠️ Sockudo AI Transport is also supported as a highly experimental backend — it requires a running Sockudo server and a worker bridge (see `docs/examples/sockudo-worker/`).
+- **Pluggable Providers**: Ollama, llama.cpp, vLLM, any OpenAI-compatible API gateway (OpenRouter, Together, etc.) with Bearer auth, and ⚠️ Sockudo AI Transport as a highly experimental backend requiring a running Sockudo server and a worker bridge (see `docs/examples/sockudo-worker/`). Ollama supports retries with backoff, configurable timeouts, and reasoning/think levels.
 - **Tool System**: 15 modular tools (`ls`, `read`, `write`, `edit`, `grep`, `glob`, `run`, `web_search`, `web_fetch`, `auto_compact`, `invoke_skill`, `switch_mode`, `question`, `screenshot`, plus the built-in `read` image loader for multimodal models).
 - **Agent Modes**: Four modes — `casual` (web-only), `planning` (read-only + signals), `agent` (full access), and `research` (web-focused) — to control what the AI can do. Modes are backed by customizable `.md` prompt files.
 - **Skills**: Pluggable SKILL.md modules discovered from `~/.config/tinyharness/skills/` and `.tinyharness/skills/`. Invokable by the AI via `invoke_skill` or by the user via `/use <name>`. Supports YAML frontmatter with name, description, compatibility, licensing, and model-invocation controls.
@@ -28,10 +28,11 @@ Lightweight AI assistant framework in Rust with pluggable LLM providers (Ollama,
 ### Prerequisites
 
 - [Rust](https://www.rust-lang.org/tools/install) (latest stable, edition 2024)
-- At least one LLM backend running locally:
-  - [Ollama](https://ollama.com/) (default)
-  - [llama.cpp](https://github.com/ggml-org/llama.cpp) server
-  - [vLLM](https://github.com/vllm-project/vllm)
+- At least one LLM backend:
+  - [Ollama](https://ollama.com/) (default, local)
+  - [llama.cpp](https://github.com/ggml-org/llama.cpp) server (local, no auth)
+  - [vLLM](https://github.com/vllm-project/vllm) (local, no auth)
+  - Any OpenAI-compatible API gateway (OpenRouter, Together, custom proxies, etc.) — requires an API key and explicit URL
   - [Sockudo](https://github.com/sockudo/sockudo) (⚠️ highly experimental — requires a worker bridge, see `docs/examples/sockudo-worker/`)
 
 ### Installation
@@ -104,6 +105,12 @@ tinyharness --vllm
 ```
 Connects to `http://127.0.0.1:8000` by default.
 
+**OpenAI-compatible gateway** (OpenRouter, Together, custom proxies, etc.):
+```bash
+tinyharness --openai-compat --url https://openrouter.ai/api/v1 --api-key <YOUR_KEY>
+```
+Requires `--url` (no default URL) and an API key. You can also set the `OPENAI_API_KEY` environment variable instead of `--api-key`. Bearer auth is sent on every request. Use `--skip-health-check` if the gateway doesn't expose a `/health` endpoint.
+
 **Sockudo** (⚠️ highly experimental):
 ```bash
 tinyharness --sockudo
@@ -117,6 +124,7 @@ A health check runs on startup to verify the provider is reachable. If the saved
 tinyharness --llama-cpp --url http://localhost:2832
 tinyharness --ollama --url http://192.168.1.50:11434
 tinyharness --vllm --url http://gpu-server:8000
+tinyharness --openai-compat --url https://api.example.com/v1 --api-key sk-xxx
 ```
 
 **Continue last session**:
@@ -151,8 +159,11 @@ Runs a guided setup: pick a provider, enter a URL, save to settings. Exits when 
 | `-o`, `--ollama` | Use the Ollama provider (default) |
 | `-l`, `--llama-cpp` | Use the llama.cpp provider |
 | `-v`, `--vllm` | Use the vLLM provider |
+| `--openai-compat` | Use a generic OpenAI-compatible gateway (requires `--api-key` and `--url`) |
 | `--sockudo` | Use the Sockudo AI Transport provider (⚠️ highly experimental) |
 | `-u`, `--url <url>` | Custom base URL for the provider |
+| `--api-key <key>` | Bearer token for `--openai-compat` (use `-` to clear saved key) |
+| `--skip-health-check` | Skip provider health check at startup |
 | `-c`, `--continue` | Continue the most recent session in the current directory |
 | `--config` | Run interactive provider setup, then exit |
 | `-p`, `--prompt <text>` | Start with this message, then drop into interactive mode |
@@ -334,12 +345,13 @@ Frontend-agnostic — no terminal I/O, no ANSI codes, no rustyline.
 tinyharness-lib/src/
 ├── lib.rs               Re-exports all public types
 ├── provider/             Provider trait + implementations
-│   ├── mod.rs            Provider trait, Message types, ToolDefinition
+│   ├── mod.rs            Provider trait, Message types, ToolDefinition, ToolCall (with id)
 │   ├── ollama.rs         OllamaProvider — raw SSE streaming, retries, Gemini signatures
-│   ├── llama_cpp.rs      LlamaCppProvider — OpenAI-compatible
-│   ├── vllm.rs           VllmProvider — OpenAI-compatible
+│   ├── llama_cpp.rs      LlamaCppProvider — OpenAI-compatible, no auth
+│   ├── vllm.rs           VllmProvider — OpenAI-compatible, no auth
 │   ├── sockudo.rs        SockudoProvider — AI Transport via WebSocket (⚠️ highly experimental)
-│   └── openai_compat.rs  Shared HTTP/SSE logic for OpenAI-compatible backends
+│   ├── openai_compat.rs      Shared HTTP/SSE logic for OpenAI-compatible backends
+│   └── openai_compat_provider.rs OpenAiCompatProvider — Bearer auth wrapper for hosted gateways
 ├── config/mod.rs         Settings persistence (provider, model, mode, API key, safe/denied commands, think type)
 ├── mode.rs               AgentMode enum (casual/planning/agent/research) with customizable .md prompts
 ├── context.rs            WorkspaceContext — auto-detected project metadata + instruction file discovery

--- a/TINYHARNESS.md
+++ b/TINYHARNESS.md
@@ -1,6 +1,6 @@
 # TinyHarness
 
-Lightweight AI assistant framework in Rust with pluggable LLM providers (Ollama, llama.cpp, vLLM), built-in tool calling, and an experimental terminal UI (TUI).
+Lightweight AI assistant framework in Rust with pluggable LLM providers (Ollama, llama.cpp, vLLM, OpenAI-compatible gateways, and experimental Sockudo AI Transport), built-in tool calling, and an experimental terminal UI (TUI).
 
 ## Commands
 
@@ -10,7 +10,7 @@ Lightweight AI assistant framework in Rust with pluggable LLM providers (Ollama,
 - Format check: `cargo fmt --all -- --check`
 - Formatting: `cargo fmt --all`
 - Install: `make install` (builds release + copies to `~/.local/bin`)
-- Run: `cargo run` (Ollama default) or `cargo run -- --llama-cpp` / `--vllm`
+- Run: `cargo run` (Ollama default) or `cargo run -- --llama-cpp` / `--vllm` / `--openai-compat --url <url> --api-key <key>` / `--sockudo`
 - TUI (experimental): `cargo run -- --tui`
 
 ## Workspace Structure
@@ -23,13 +23,13 @@ Three crates in a Cargo workspace:
 
 ### Key `tinyharness-lib` modules
 
-- `provider/` — Provider trait, `OllamaProvider` (raw SSE, Gemini signatures), `LlamaCppProvider`/`VllmProvider` (shared OpenAI-compat internals)
+- `provider/` — Provider trait, `OllamaProvider` (raw SSE, Gemini signatures), `LlamaCppProvider`/`VllmProvider` (shared OpenAI-compat internals, no auth), `OpenAiCompatProvider` (Bearer auth for hosted gateways), `SockudoProvider` (WebSocket, ⚠️ experimental). `ToolCall` carries optional `id`, `Message` carries optional `tool_call_id`.
 - `tools/` — 15 tools (ls, read, write, edit, grep, glob, run, web_search, web_fetch, switch_mode, question, auto_compact, invoke_skill, screenshot), registration in `register_defaults()`, mode-based filtering
 - `session.rs` — JSONL persistence, auto-save every 5 messages
 - `context.rs` — Workspace metadata + instruction file discovery (TINYHARNESS.md → .tinyharness.md → AGENTS.md → CLAUDE.md)
 - `skill.rs` — Skill discovery from `~/.config/tinyharness/skills/` and `.tinyharness/skills/`
 - `mode.rs` — Agent modes with `.md` system prompts
-- `config/mod.rs` — SettingsStore, ProviderKind, OllamaThinkType
+- `config/mod.rs` — SettingsStore, ProviderKind (ollama/llamacpp/vllm/openai-compat/sockudo), OllamaThinkType
 
 ### Binary crate structure
 
@@ -54,7 +54,7 @@ Three crates in a Cargo workspace:
 2. Agent loop: read input (or `--prompt`), dispatch slash commands, send messages to provider, stream response, handle tool calls
 3. Signal tools (`switch_mode`, `question`, `auto_compact`, `invoke_skill`) bypass generic tool execution and are handled inline
 4. Destructive tools prompt for confirmation (except `run` which cannot be auto-accepted); ReadOnly tools run immediately
-5. Tool results are batched into a single `Role::Tool` message, appended to conversation
+5. Tool results are batched into a single `Role::Tool` message, appended to conversation. Each tool result carries `tool_call_id` linking it back to the originating `ToolCall.id` (required by OpenAI-compatible servers).
 6. Auto-save session every 5 messages; flush on mode switch, session switch, exit
 
 ## Agent Modes
@@ -69,15 +69,15 @@ Three crates in a Cargo workspace:
 ## Testing
 
 - `cargo test --workspace` runs all tests
-- `tinyharness-lib` has good coverage (~84 tests); `tinyharness-ui` has extensive coverage (~325 tests, including TUI rendering, Unicode width, scroll/clipping, and overflow tests); binary crate has limited coverage (see `todo/01-testing-gaps.md`)
+- `tinyharness-lib` has good coverage (~89 tests); `tinyharness-ui` has extensive coverage (~325 tests, including TUI rendering, Unicode width, scroll/clipping, and overflow tests); binary crate has limited coverage (see `todo/01-testing-gaps.md`)
 - Use `tempfile` for test isolation; tool tests must not touch the real filesystem
 - Run specific test: `cargo test <test_name>`
 - Run per crate: `cargo test -p tinyharness-lib`, `cargo test -p TinyHarness`, `cargo test -p tinyharness-ui`
 
 ## Important Rules & Gotchas
 
-- **Provider startup**: All providers run a health check (Ollama calls `list_local_models`). If saved model is unavailable, auto-select picks the first available with a warning.
-- **Ollama specifics**: Own raw SSE parser (not ollama-rs streaming) to handle native and OpenAI-compatible formats; captures Gemini `thought_signature` from tool responses and re-injects them; fixes serialization quirks (lowercases tool type, injects `name` in tool results).
+- **Provider startup**: All providers run a health check (Ollama calls `list_local_models`). If saved model is unavailable, auto-select picks the first available with a warning. Use `--skip-health-check` to bypass (useful for gateways without `/health`). `--openai-compat` requires `--api-key` (or `OPENAI_API_KEY` env var) and `--url`.
+- **Ollama specifics**: Own raw SSE parser (not ollama-rs streaming) to handle native and OpenAI-compatible formats; captures Gemini `thought_signature` from tool responses and re-injects them; fixes serialization quirks (lowercases tool type, injects `name` in tool results, synthesizes `tool_call_id` when missing for OpenAI-compatible servers).
 - **System prompts**: Assembled from `header.md` + `<mode>.md` for Agent/Planning/Research; Casual is self-contained. Prompts are refreshed on mode switch, file pinning changes, skill activation, and `/refresh`.
 - **Command safety** (`src/agent/safety.rs`): Prefix matching with word boundaries, deny list priority, strips redirections before matching; rejects `;`, `&`, `|`, `$()`, backticks, newlines. Redirections like `2>&1` are auto-accepted if base command is safe.
 - **Confirmation**: `run` tool cannot be auto-accepted even with 'a' (auto-accept mode); only `write` and `edit` can.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,9 @@
 | Provider | Status | Notes |
 |----------|--------|-------|
 | Ollama | Stable (default) | Raw SSE streaming, retries, think levels, API key for web tools |
-| llama.cpp | Stable | OpenAI-compatible, shared HTTP/SSE logic |
-| vLLM | Stable | OpenAI-compatible, shared HTTP/SSE logic |
+| llama.cpp | Stable | OpenAI-compatible, shared HTTP/SSE logic, no auth (local servers) |
+| vLLM | Stable | OpenAI-compatible, shared HTTP/SSE logic, no auth (local servers) |
+| OpenAI-compat | Stable | Generic OpenAI-compatible gateways (OpenRouter, Together, etc.) with Bearer auth. Requires `--api-key` and `--url` |
 | Sockudo | ⚠️ Highly experimental | AI Transport via WebSocket, requires a worker bridge (see `docs/examples/sockudo-worker/`) |
 
 ## Quick References

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,11 @@ Settings are saved atomically: written to a `.tmp` file, then renamed. This prev
   "last_model": "qwen2.5-coder:14b",
   "preferred_mode": "agent",
   "ollama_api_key": null,
+  "openai_compat_api_key": null,
+  "sockudo_app_id": null,
+  "sockudo_app_key": null,
+  "sockudo_app_secret": null,
+  "skip_health_check": false,
   "ollama_timeout_secs": 5,
   "ollama_max_retries": 3,
   "ollama_think_type": "medium",
@@ -45,7 +50,7 @@ Settings are saved atomically: written to a `.tmp` file, then renamed. This prev
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `last_provider` | string | `"ollama"` | Last used provider: `"ollama"`, `"llamacpp"`, `"vllm"`, or `"sockudo"` |
+| `last_provider` | string | `"ollama"` | Last used provider: `"ollama"`, `"llamacpp"`, `"vllm"`, `"openai-compat"`, or `"sockudo"` |
 | `last_provider_url` | string\|null | `null` | Custom base URL for the provider. Set by `--url` flag or `--config` interactive setup. If `null`, uses the provider's default URL |
 | `last_model` | string\|null | `null` | Last used model name. Set by `/model <name>`. If `null`, the provider auto-selects the first available model |
 
@@ -53,7 +58,21 @@ Settings are saved atomically: written to a `.tmp` file, then renamed. This prev
 - Ollama: `http://127.0.0.1:11434`
 - llama.cpp: `http://127.0.0.1:8080`
 - vLLM: `http://127.0.0.1:8000`
+- OpenAI-compat: _(none — `--url` is required)_
 - Sockudo: `http://127.0.0.1:6001` (⚠️ highly experimental)
+
+### OpenAI-Compatible Provider Settings
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `openai_compat_api_key` | string\|null | `null` | Bearer token for `--openai-compat` provider. Sent as `Authorization: Bearer <key>`. Set via `--api-key <key>`, `OPENAI_API_KEY` env var, or `--config` interactive setup. Use `--api-key -` to clear the saved key |
+| `skip_health_check` | bool | `false` | Skip the provider health check at startup. Useful for gateways without a `/health` endpoint. Set via `--skip-health-check` |
+
+**API key resolution precedence:**
+1. `--api-key <key>` CLI flag (highest — also persists to settings)
+2. `OPENAI_API_KEY` environment variable
+3. `openai_compat_api_key` in settings.json
+4. None (provider startup fails with an error)
 
 ### Sockudo Provider (Experimental)
 
@@ -278,8 +297,11 @@ All CLI flags override settings:
 | `-o`, `--ollama` | `last_provider = "ollama"` |
 | `-l`, `--llama-cpp` | `last_provider = "llamacpp"` |
 | `-v`, `--vllm` | `last_provider = "vllm"` |
+| `--openai-compat` | `last_provider = "openai-compat"` (requires `--api-key` and `--url`) |
 | `--sockudo` | `last_provider = "sockudo"` (⚠️ experimental) |
 | `-u`, `--url <url>` | `last_provider_url = <url>` |
+| `--api-key <key>` | `openai_compat_api_key = <key>` (only affects `--openai-compat`; use `-` to clear) |
+| `--skip-health-check` | Skips provider health check at startup |
 | `-c`, `--continue` | Loads most recent session (doesn't modify settings) |
 | `--config` | Runs interactive setup, saves, exits |
 | `-p`, `--prompt <text>` | Sends initial prompt then enters interactive mode |
@@ -292,4 +314,5 @@ All CLI flags override settings:
 | Variable | Effect |
 |----------|--------|
 | `TINYHARNESS_MD_FILES` | Comma-separated list of instruction file names, overrides `project_md_files` in settings |
+| `OPENAI_API_KEY` | Bearer token for the `--openai-compat` provider (used when `--api-key` is not passed) |
 | `HOME` | Used to resolve `~/.config/tinyharness/` and `~/.local/share/tinyharness/` |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,7 +26,7 @@ cargo build --workspace
 cargo test --workspace
 ```
 
-This compiles all three crates and runs the test suite (~450 tests across all crates).
+This compiles all three crates and runs the test suite (~490 tests across all crates).
 
 ---
 
@@ -42,7 +42,13 @@ TinyHarness/                  Binary crate — CLI, agent loop, slash commands
 tinyharness-lib/              Core library — no terminal I/O, no ANSI, no rustyline
 ├── src/
 │   ├── lib.rs                Re-exports all public types
-│   ├── provider/             Provider trait + Ollama/llama.cpp/vLLM/Sockudo impls
+│   ├── provider/             Provider trait + Ollama/llama.cpp/vLLM/OpenAI-compat/Sockudo impls
+│   │   ├── ollama.rs             OllamaProvider — raw SSE streaming, retries, Gemini signatures
+│   │   ├── llama_cpp.rs          LlamaCppProvider — OpenAI-compatible, no auth (local)
+│   │   ├── vllm.rs               VllmProvider — OpenAI-compatible, no auth (local)
+│   │   ├── openai_compat.rs      Shared HTTP/SSE logic for OpenAI-compatible backends
+│   │   ├── openai_compat_provider.rs OpenAiCompatProvider — Bearer auth wrapper for hosted gateways
+│   │   └── sockudo.rs            SockudoProvider — AI Transport via WebSocket (⚠️ experimental)
 │   ├── tools/                15 tools + ToolManager with mode filtering
 │   ├── config/mod.rs         Settings, project settings, prompt management
 │   ├── context.rs            Workspace detection, instruction file discovery
@@ -190,7 +196,7 @@ Use `serde` + `schemars` for serialization and JSON Schema generation:
 
 - Use `tempfile` for test isolation — tool tests must not touch the real filesystem
 - Test modules go inline: `#[cfg(test)] mod tests { ... }`
-- `tinyharness-lib` has good coverage (~84 tests); `tinyharness-ui` has extensive coverage (~325 tests, including TUI rendering, Unicode width, scroll/clipping, and overflow tests); binary crate has limited coverage (see `todo/01-testing-gaps.md`)
+- `tinyharness-lib` has good coverage (~89 tests); `tinyharness-ui` has extensive coverage (~325 tests, including TUI rendering, Unicode width, scroll/clipping, and overflow tests); binary crate has limited coverage (see `todo/01-testing-gaps.md`)
 
 ### Tool Categories
 
@@ -207,12 +213,14 @@ See [Tools Reference](tools-reference.md) for the full list and behavior.
 
 GitHub Actions runs on every push and PR to `master`:
 
-| Job | Command | Purpose |
-|-----|---------|---------|
-| Format | `cargo fmt --all -- --check` | Ensures consistent formatting |
-| Clippy | `cargo clippy --workspace -- -D warnings` | Catches common mistakes |
-| Test | `cargo test --workspace` | Runs full test suite |
-| Build | `cargo build --workspace` | Confirms compilation |
+| Job | Platform | Command | Purpose |
+|-----|----------|---------|---------|
+| Format | Linux | `cargo fmt --all -- --check` | Ensures consistent formatting |
+| Clippy | Linux | `cargo clippy --workspace -- -D warnings` | Catches common mistakes |
+| Test | Linux | `cargo test --workspace` | Runs full test suite |
+| Build | Linux | `cargo build --workspace` | Confirms compilation |
+| Build | Windows | `cargo build --workspace` | Confirms Windows compilation |
+| Test | Windows | `cargo test --workspace` | Runs full test suite on Windows |
 
 Uses `dtolnay/rust-toolchain@stable` for Rust and `Swatinem/rust-cache@v2` for caching.
 
@@ -299,6 +307,7 @@ pub fn handle_my_command(ctx: &mut CommandContext, _args: &[&str]) -> CommandRes
 
 - **Code questions**: Look at existing patterns — most modules follow consistent idioms
 - **Architecture**: Read `TINYHARNESS.md` (the project's own instructions) and the module overview above
+- **OpenAI-compat provider**: See [Configuration Guide](configuration.md#openai-compatible-provider-settings) for API key setup
 - **Sockudo provider**: ⚠️ Highly experimental — see [Configuration Guide](configuration.md#sockudo-provider-experimental) for setup and limitations
 - **Planned work**: Check `todo/todo.md` and `todo/<number>-*.md` for tracked enhancements
 - **Tool docs**: See [Tools Reference](tools-reference.md) for tool schemas and behavior

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -209,7 +209,7 @@ All parameters are passed as strings to keep parsing simple. For non-string type
 
 ### Tool Call Format
 
-The model emits tool calls in XML block format with `tool_calls` and `invoke` elements. Multiple tools can be called in a single block. Results are batched into a single response message.
+The model emits tool calls in XML block format with `tool_calls` and `invoke` elements. Multiple tools can be called in a single block. Results are batched into a single response message. Each tool call includes an `id` (OpenAI tool call ID) that is echoed back in the matching `Role::Tool` result message via `tool_call_id`, as required by OpenAI-compatible servers. Signal tools also propagate `tool_call_id` through the agent loop.
 
 ---
 


### PR DESCRIPTION
…ws CI

Update all documentation to reflect recent v0.3.0 changes:

- New --openai-compat provider with Bearer auth, --api-key flag, OPENAI_API_KEY env var, and --skip-health-check option
- New settings fields: openai_compat_api_key, skip_health_check, sockudo_app_id/key/secret
- tool_call_id propagation through signal tools and ToolCall.id
- Windows CI jobs (build + test)
- Test count update: 84 → 89 (tinyharness-lib), ~450 → ~490 total
- Provider tree structure expanded in contributing.md and README.md
- llama.cpp/vLLM clarified as no-auth (local servers)

Affected files:
- README.md
- TINYHARNESS.md
- docs/README.md
- docs/configuration.md
- docs/contributing.md
- docs/tools-reference.md