### PR TITLE
fix: send null content in assistant messages with tool calls for MiniMax

### DIFF
--- a/tinyharness-lib/src/provider/openai_compat.rs
+++ b/tinyharness-lib/src/provider/openai_compat.rs
@@ -339,7 +339,14 @@ pub fn to_openai_message(msg: Message) -> OpenAIMessage {
                     .collect();
                 OpenAIMessage {
                     role: "assistant".to_string(),
-                    content: serde_json::Value::String(msg.content),
+                    // MiniMax and some other strict providers reject empty
+                    // strings in assistant messages that contain only tool
+                    // calls.  Send `null` when there is no text content.
+                    content: if msg.content.is_empty() {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::Value::String(msg.content)
+                    },
                     tool_calls: Some(tool_calls),
                     tool_call_id: None,
                 }


### PR DESCRIPTION
MiniMax (and other strict OpenAI-compatible providers) reject assistant messages with empty string content when tool_calls are present — they require content: null.

This fix changes the assistant message serialization in openai_compat.rs to emit serde_json::Value::Null instead of empty string when there are tool_calls and no text content.

Fixes error from MiniMax gateway: 'tool call result does not follow tool call (2013)'

Reference: opencode implements the same pattern in packages/llm/src/protocols/openai-chat.ts