### PR TITLE
build(nix): add deny and audit to flake checks

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782467904,
+        "narHash": "sha256-2ROADxDdmTMFV+jbwPbCU33qNZIO+WRcpUXmoQGLTLI=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "e69927bf37afb7707575bc95aff6a9ef3f2534fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1780532242,
@@ -51,6 +67,7 @@
     },
     "root": {
       "inputs": {
+        "advisory-db": "advisory-db",
         "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,13 @@
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, crane, rust-overlay, ... }:
+  outputs = { self, nixpkgs, flake-utils, crane, rust-overlay, advisory-db, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -33,6 +37,13 @@
           filter = path: type:
             (craneLib.filterCargoSources path type) ||
             (lib.hasSuffix ".md" path);
+          src = lib.cleanSource ./.;
+        };
+
+        denySrc = lib.cleanSourceWith {
+          filter = path: type:
+            (craneLib.filterCargoSources path type) ||
+            (lib.hasSuffix "deny.toml" path);
           src = lib.cleanSource ./.;
         };
 
@@ -78,6 +89,14 @@
           });
           fmt = craneLib.cargoFmt {
             inherit src;
+          };
+          deny = craneLib.cargoDeny {
+            src = denySrc;
+            cargoDenyExtraArgs = "--all-features";
+          };
+          audit = craneLib.cargoAudit {
+            src = craneLib.cleanCargoSource ./.;
+            inherit advisory-db;
           };
         };
 


### PR DESCRIPTION
- Add flake check for `cargo deny`
- Add flake check for `cargo audit`

`cargo deny` and `audit` were recently added to the CI checks. Update the nix flake to match.