### PR TITLE
docs: sync documentation with current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lightweight AI assistant framework in Rust with pluggable LLM providers (Ollama,
 - **Session Persistence**: JSONL-based sessions with UUIDs, saved in `~/.local/share/tinyharness/sessions/`. Supports session listing, switching by prefix, renaming, deletion, and auto-save every 5 messages.
 - **Async Streaming**: Built on `tokio` for efficient streaming with all providers. Ctrl+C interrupts generation gracefully.
 - **Experimental TUI**: Split-pane terminal UI with conversation view, sidebar, input bar, and tool output panel. Built from scratch with no external TUI framework. Activate with `--tui`. ⚠️ Experimental — may have rendering issues or incomplete features.
-- **Interactive CLI**: Color-coded terminal interface with 22+ slash commands for session management, configuration, file pinning, image attachment, audit logging, and tool control.
+- **Interactive CLI**: Color-coded terminal interface with 24+ slash commands for session management, configuration, file pinning, image attachment, audit logging, debug diagnostics, and tool control.
 - **Customizable Prompts**: System prompts are seeded from hardcoded defaults on first launch to `~/.config/tinyharness/prompts/` and can be freely edited.
 - **Command Safety**: Smart auto-accept for safe shell commands with prefix matching, deny lists, redirection stripping, and audit logging.
 - **Thinking Display**: Optionally render the model's reasoning chain inline during streaming (toggle via `/showthink`).
@@ -249,7 +249,8 @@ Switch modes with `/mode <name>`, use shortcut aliases (`/plan`, `/agent`, `/res
 | `/command [list\|add\|rm\|deny\|undeny\|reset\|resetdeny]` | Manage auto-accepted and denied commands |
 | `/apikey [key\|clear]` | Set, show, or clear the Ollama API key (needed for `web_search`) |
 | `/contextlimit [tokens]` | Show or set the context warning threshold |
-| `/autoaccept [on\|off]` | Toggle auto-accept for safe read-only commands |
+| `/autoaccept [all\|safe\|off]` | Show or set auto-accept mode (`off`, `safe` = read-only, `all` = all tools except `run`) |
+| `/autocompact [on\|off]` | Toggle the auto_compact tool (when off, the model cannot request compaction) |
 | `/showthink [on\|off]` | Toggle display of the model's thinking/reasoning chain |
 | `/timeout <seconds>` | Set Ollama request timeout (default: 5s) |
 | `/retries <count>` | Set Ollama max retries (default: 3) |
@@ -261,6 +262,7 @@ Switch modes with `/mode <name>`, use shortcut aliases (`/plan`, `/agent`, `/res
 |---------|-------------|
 | `/help` | Show available commands |
 | `/clear` | Clear terminal screen |
+| `/debug [path]` | Dump full conversation context to a log file (for diagnostics) |
 | `/exit` or `/quit` | Exit TinyHarness |
 
 ### Command Management
@@ -356,6 +358,7 @@ tinyharness-lib/src/
 ├── session.rs            JSONL session persistence with UUIDs, auto-save, atomic writes
 ├── token.rs              Token estimation, context window sizes (8K–256K), usage warnings
 ├── skill.rs              Skill discovery, registry, frontmatter parsing, indexing
+├── secret.rs             SecretString wrapper for API key redaction (custom Debug, serde support)
 ├── image.rs              Image attachment handling (base64 encoding, dimension detection)
 ├── prompts/              Hardcoded default system prompts (header.md, casual.md, planning.md, agent.md, research.md)
 └── tools/                15 tool implementations
@@ -428,17 +431,22 @@ src/
 │   ├── safety.rs         Shell command safety checker (prefix + deny list + redirection stripping)
 │   ├── setup.rs          Interactive provider setup (--config), URL prompting
 │   ├── display.rs        Context status formatting, args summaries, listing result summaries
-│   └── input.rs          Multi-line input reading with continuation prompt
+│   ├── input.rs          Multi-line input reading with continuation prompt
+│   ├── confirm.rs        Confirmation prompt rendering for tool calls
+│   ├── signal.rs         Signal tool handling (switch_mode, question, auto_compact, invoke_skill)
+│   ├── tool_result.rs    Tool result formatting and batching
+│   └── command_result.rs CommandResult enum definition
 └── commands/
-    ├── mod.rs            CommandRegistry, CommandDispatcher, build_registry() — 22+ commands
+    ├── mod.rs            CommandRegistry, CommandDispatcher, build_registry() — 24+ commands
     ├── registry.rs       CommandContext, CommandResult, AsyncCommand trait, async_command! macro
     ├── apikey.rs         /apikey — Ollama API key management
     ├── audit.rs          /audit — command execution audit log
     ├── clear.rs          /clear — terminal clear
     ├── command.rs        /command — safe/denied command management
     ├── compact.rs        /compact — cascading conversation summarization
-    ├── config_settings.rs /contextlimit, /autoaccept, /showthink, /timeout, /retries, /think
+    ├── config_settings.rs /contextlimit, /autoaccept, /autocompact, /showthink, /timeout, /retries, /think
     ├── context.rs        /context — workspace context display
+    ├── debug.rs          /debug — full conversation context dump to log file
     ├── exit.rs           /exit — graceful shutdown
     ├── files.rs          /add, /drop, /files, /dropall, /refresh — file pinning
     ├── help.rs           /help — command listing
@@ -446,6 +454,7 @@ src/
     ├── init.rs           /init — TINYHARNESS.md generation
     ├── mode.rs           /mode — mode switching
     ├── models.rs         /model — model listing and selection
+    ├── project_settings.rs /project-settings — per-project settings display and init
     ├── sessions.rs       /sessions, /session — session listing, switching, deletion
     ├── settings.rs       /settings — configuration display
     └── skill.rs          /skills, /skill, /use, /unload — skill management
@@ -492,7 +501,7 @@ TinyHarness grants LLMs the ability to interact with your filesystem through too
 - **Non-determinism**: LLMs may hallucinate or produce incorrect tool arguments. Always review proposed actions.
 - **Accountability**: You assume full responsibility for all operations performed by the AI. Ensure you have backups.
 
-The `run` tool can never be auto-accepted — even with auto-accept mode (`a`) — unlike `write` and `edit`. Safe commands (e.g., `ls`, `git status`) can be auto-accepted when `/autoaccept` is on.
+The `run` tool can never be auto-accepted — even in `all` mode — unlike `write` and `edit`. Safe commands (e.g., `ls`, `git status`) can be auto-accepted when `/autoaccept` is set to `safe` or `all`.
 
 ## Project Instructions (TINYHARNESS.md)
 
@@ -576,7 +585,7 @@ TinyHarness supports per-project configuration via `.tinyharness/config.json`, d
 {
   "safe_command_prefixes": ["python -m pytest", "npm run lint"],
   "denied_command_prefixes": ["git push --force"],
-  "auto_accept_safe_commands": false,
+  "auto_accept_mode": "off",
   "context_limit": 32768,
   "project_md_files": ["RULES.md", ".cursorrules"],
   "preferred_mode": "agent"
@@ -585,7 +594,7 @@ TinyHarness supports per-project configuration via `.tinyharness/config.json`, d
 
 - **`safe_command_prefixes`**: Extends (not replaces) the global safe list
 - **`denied_command_prefixes`**: Replaces the global deny list entirely
-- **`auto_accept_safe_commands`**: Overrides global toggle
+- **`auto_accept_mode`**: Overrides global auto-accept mode (`"off"`, `"safe"`, or `"all"`)
 - **`context_limit`**: Overrides context warning threshold
 - **`project_md_files`**: Additional instruction files loaded after the main one
 - **`preferred_mode`**: Default agent mode for this project

--- a/TINYHARNESS.md
+++ b/TINYHARNESS.md
@@ -29,13 +29,14 @@ Three crates in a Cargo workspace:
 - `context.rs` — Workspace metadata + instruction file discovery (TINYHARNESS.md → .tinyharness.md → AGENTS.md → CLAUDE.md)
 - `skill.rs` — Skill discovery from `~/.config/tinyharness/skills/` and `.tinyharness/skills/`
 - `mode.rs` — Agent modes with `.md` system prompts
-- `config/mod.rs` — SettingsStore, ProviderKind (ollama/llamacpp/vllm/openai-compat/sockudo), OllamaThinkType
+- `secret.rs` — `SecretString` wrapper for API key redaction (custom `Debug` impl, serde support)
+- `config/mod.rs` — SettingsStore, ProviderKind (ollama/llamacpp/vllm/openai-compat/sockudo), OllamaThinkType, AutoAcceptMode (off/safe/all)
 
 ### Binary crate structure
 
-- `src/agent/` — Agent loop, tool execution, safety checks, display, multi-line input, provider setup
+- `src/agent/` — Agent loop (`mod.rs`), tool execution (`tools.rs`), safety checks (`safety.rs`), display (`display.rs`), multi-line input (`input.rs`), provider setup (`setup.rs`), confirmation prompts (`confirm.rs`), signal tool handling (`signal.rs`), tool result formatting (`tool_result.rs`), command result types (`command_result.rs`)
 - `src/agent/tui_loop.rs` — Background agent loop for TUI mode (communicates with TUI via mpsc channels)
-- `src/commands/` — 22+ slash commands (mode, model, sessions, compact, init, context, files, image, skill, settings, help, etc.), `CommandRegistry` and `async_command!` macro
+- `src/commands/` — 24+ slash commands (mode, model, sessions, compact, init, context, files, image, skill, settings, help, debug, project-settings, autocompact, etc.), `CommandRegistry` and `async_command!` macro
 
 ## Code Conventions
 
@@ -69,7 +70,7 @@ Three crates in a Cargo workspace:
 ## Testing
 
 - `cargo test --workspace` runs all tests
-- `tinyharness-lib` has good coverage (~89 tests); `tinyharness-ui` has extensive coverage (~325 tests, including TUI rendering, Unicode width, scroll/clipping, and overflow tests); binary crate has limited coverage (see `todo/01-testing-gaps.md`)
+- `tinyharness-lib` has good coverage (~101 tests); `tinyharness-ui` has extensive coverage (~325 tests, including TUI rendering, Unicode width, scroll/clipping, and overflow tests); binary crate has ~99 tests + 13 ignored (see `todo/01-testing-gaps.md`)
 - Use `tempfile` for test isolation; tool tests must not touch the real filesystem
 - Run specific test: `cargo test <test_name>`
 - Run per crate: `cargo test -p tinyharness-lib`, `cargo test -p TinyHarness`, `cargo test -p tinyharness-ui`
@@ -80,7 +81,7 @@ Three crates in a Cargo workspace:
 - **Ollama specifics**: Own raw SSE parser (not ollama-rs streaming) to handle native and OpenAI-compatible formats; captures Gemini `thought_signature` from tool responses and re-injects them; fixes serialization quirks (lowercases tool type, injects `name` in tool results, synthesizes `tool_call_id` when missing for OpenAI-compatible servers).
 - **System prompts**: Assembled from `header.md` + `<mode>.md` for Agent/Planning/Research; Casual is self-contained. Prompts are refreshed on mode switch, file pinning changes, skill activation, and `/refresh`.
 - **Command safety** (`src/agent/safety.rs`): Prefix matching with word boundaries, deny list priority, strips redirections before matching; rejects `;`, `&`, `|`, `$()`, backticks, newlines. Redirections like `2>&1` are auto-accepted if base command is safe.
-- **Confirmation**: `run` tool cannot be auto-accepted even with 'a' (auto-accept mode); only `write` and `edit` can.
+- **Confirmation**: `run` tool cannot be auto-accepted even with 'a' (auto-accept mode); only `write` and `edit` can. Auto-accept has three modes: `off`, `safe` (read-only commands), `all` (all destructive tools except `run`).
 - **Compaction**: `/compact` uses single-pass for ≤200 intermediate messages, cascading (chunk+merge) for larger sessions.
 - **Context warnings**: Load warnings at 70%/90% thresholds based on last known token count (estimation).
 - **Session files**: JSONL (metadata line first, then message lines); malformed lines silently skipped on load; stored in `~/.local/share/tinyharness/sessions/`.
@@ -90,7 +91,7 @@ Three crates in a Cargo workspace:
 - **Image attachments**: Base64 data URIs, used by multimodal models; set via `/image`.
 - **`async_command!` macro**: Registers commands that need `provider.lock().await`.
 - **`CommandResult` variants**: `SwitchSession`, `RenameSession`, `Init`, `SkillUse`, `SkillUnload` carry data back to the agent loop.
-- **`CommandContext`** holds shared mutable state: provider, mode, file context, session ID, skill registry, active skills, pending images, thinking toggle, compaction token usage.
+- **`CommandContext`** holds shared mutable state: provider, mode, file context, session ID, skill registry, active skills, pending images, thinking toggle, compaction token usage, workspace context, prompts dir, output writer, exit flag.
 - **`extract_args!` macro** exported at `tinyharness_lib` root, not in `tools`.
 
 ## Verification Steps

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,8 @@ Settings are saved atomically: written to a `.tmp` file, then renamed. This prev
   "ollama_think_type": "medium",
   "show_thinking": false,
   "context_limit": null,
-  "auto_accept_safe_commands": true,
+  "auto_accept_mode": "safe",
+  "auto_compact_enabled": true,
   "safe_command_prefixes": null,
   "denied_command_prefixes": null,
   "project_md_files": null
@@ -137,7 +138,8 @@ Can be overridden per-project via `.tinyharness/config.json` → `preferred_mode
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `auto_accept_safe_commands` | bool | `true` | Whether safe commands auto-execute without confirmation. Toggle with `/autoaccept` |
+| `auto_accept_mode` | string | `"safe"` | Auto-accept mode: `"off"`, `"safe"` (read-only commands), or `"all"` (all destructive tools except `run`). Toggle with `/autoaccept`. Legacy `auto_accept_safe_commands` (bool) and `auto_accept_all` (bool) are auto-migrated to this field. |
+| `auto_compact_enabled` | bool | `true` | Whether the `auto_compact` tool is available to the model. Toggle with `/autocompact` |
 | `safe_command_prefixes` | vec\|null | `null` | Custom safe command prefixes. If `null`, uses the hardcoded default list (43 commands). Set via `/command add/rm/reset` |
 | `denied_command_prefixes` | vec\|null | `null` | Always-denied prefixes. Takes priority over safe list. Set via `/command deny/undeny/resetdeny` |
 
@@ -168,7 +170,7 @@ Overrides global settings for a specific project. See [Per-Project Settings](per
 {
   "safe_command_prefixes": ["python -m pytest", "npm run lint"],
   "denied_command_prefixes": ["git push --force"],
-  "auto_accept_safe_commands": false,
+  "auto_accept_mode": "off",
   "context_limit": 32768,
   "project_md_files": ["RULES.md", ".cursorrules"],
   "preferred_mode": "agent"
@@ -199,7 +201,7 @@ Shows every setting with its source annotation:
 safe_command_prefixes    (project):
   python -m pytest
   ...
-auto_accept_safe_commands (project): false
+auto_accept_mode         (project): off
 context_limit             (project): 32768
 last_provider             (global):  ollama
 ollama_timeout_secs       (default): 5

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,7 +26,7 @@ cargo build --workspace
 cargo test --workspace
 ```
 
-This compiles all three crates and runs the test suite (~490 tests across all crates).
+This compiles all three crates and runs the test suite (~540 tests across all crates).
 
 ---
 
@@ -37,7 +37,7 @@ TinyHarness/                  Binary crate — CLI, agent loop, slash commands
 ├── src/
 │   ├── main.rs               Entry point, CLI parsing, provider creation
 │   ├── agent/                Agent loop, tool execution, safety, display, input
-│   └── commands/             22+ slash command modules + registry
+│   └── commands/             24+ slash command modules + registry
 │
 tinyharness-lib/              Core library — no terminal I/O, no ANSI, no rustyline
 ├── src/
@@ -53,6 +53,7 @@ tinyharness-lib/              Core library — no terminal I/O, no ANSI, no rust
 │   ├── session.rs            JSONL persistence, auto-save, atomic writes
 │   ├── token.rs              Token estimation, context windows, warnings
 │   ├── skill.rs              Skill discovery, registry, frontmatter parsing
+│   ├── secret.rs             SecretString wrapper for API key redaction
 │   ├── image.rs              Image attachment handling
 │   ├── mode.rs               AgentMode enum, prompt assembly
 │   └── prompts/              Hardcoded default system prompts (.md files)
@@ -194,7 +195,7 @@ Use `serde` + `schemars` for serialization and JSON Schema generation:
 
 - Use `tempfile` for test isolation — tool tests must not touch the real filesystem
 - Test modules go inline: `#[cfg(test)] mod tests { ... }`
-- `tinyharness-lib` has good coverage (~89 tests); `tinyharness-ui` has extensive coverage (~325 tests, including TUI rendering, Unicode width, scroll/clipping, and overflow tests); binary crate has limited coverage (see `todo/01-testing-gaps.md`)
+- `tinyharness-lib` has good coverage (~101 tests); `tinyharness-ui` has extensive coverage (~325 tests, including TUI rendering, Unicode width, scroll/clipping, and overflow tests); binary crate has ~99 tests + 13 ignored (see `todo/01-testing-gaps.md`)
 
 ### Tool Categories
 

--- a/docs/per-project-settings.md
+++ b/docs/per-project-settings.md
@@ -27,7 +27,7 @@ This generates `.tinyharness/config.json` in your project root with all availabl
 
 ```json
 {
-  "auto_accept_safe_commands": true
+  "auto_accept_mode": "safe"
 }
 ```
 
@@ -57,17 +57,17 @@ Always blocks these commands from auto-accept, even if they'd match a safe prefi
 }
 ```
 
-### `auto_accept_safe_commands`
+### `auto_accept_mode`
 
-Toggle whether safe commands are auto-accepted without confirmation.
+Override the global auto-accept mode. Values: `"off"`, `"safe"` (read-only commands auto-accepted), or `"all"` (all destructive tools except `run`).
 
 ```json
 {
-  "auto_accept_safe_commands": false
+  "auto_accept_mode": "off"
 }
 ```
 
-Set to `false` on sensitive projects to require manual approval for every command.
+Set to `"off"` on sensitive projects to require manual approval for every command.
 
 ### `context_limit`
 
@@ -134,7 +134,7 @@ Legend: (project) = from .tinyharness/config.json
 
 ```json
 {
-  "auto_accept_safe_commands": false,
+  "auto_accept_mode": "off",
   "denied_command_prefixes": ["rm", "mv", "chmod", "chown", "sudo"]
 }
 ```

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -178,20 +178,24 @@ Confirm? (Y)es / (N)o / (A)uto-accept future
 
 ### Auto-Accept Mode
 
-Toggle with `/autoaccept on` or `/autoaccept off`.
+Toggle with `/autoaccept off`, `/autoaccept safe`, or `/autoaccept all`.
 
-When on (`auto_accept_safe_commands: true`):
+**`off`** (default):
+- All destructive tools prompt for confirmation
+- No auto-accept toggle is offered
+
+**`safe`** (`auto_accept_mode: "safe"`):
 - **ReadOnly** tools auto-execute (always, regardless of this setting)
 - **Destructive** `write` and `edit` get a prompt — but pressing `A` during confirmation enables auto-accept for the rest of the session
 - **Destructive** `run` is NEVER auto-accepted, even with `A`
 
-When off:
-- All destructive tools prompt for confirmation
-- No auto-accept toggle is offered
+**`all`** (`auto_accept_mode: "all"`):
+- **Destructive** `write` and `edit` auto-execute without prompting
+- **Destructive** `run` still prompts — it is NEVER auto-accepted, even in `all` mode
 
 ### `run` Tool Special Rule
 
-The `run` tool can **never** be auto-accepted, even with `/autoaccept on` and pressing `A`. This is a hard rule — if commands are safe, they pass the safety checker and auto-execute. If they're not, you must confirm them individually.
+The `run` tool can **never** be auto-accepted, even with `/autoaccept all` and pressing `A`. This is a hard rule — if commands are safe, they pass the safety checker and auto-execute. If they're not, you must confirm them individually.
 
 ---
 
@@ -202,7 +206,7 @@ The `run` tool can **never** be auto-accepted, even with `/autoaccept on` and pr
 1. **Sandbox**: Run TinyHarness inside a Docker container or VM for untrusted models
 2. **Review before confirming**: Always read the proposed command before pressing `Y`
 3. **Use the deny list**: Block commands you never want auto-executed: `/command deny "git push --force"`
-4. **Per-project settings**: Set `auto_accept_safe_commands: false` for sensitive projects
+4. **Per-project settings**: Set `auto_accept_mode: "off"` for sensitive projects
 5. **Limit tools by mode**: Use `planning` mode for analysis, switch to `agent` only when you need destructive operations
 6. **Check the audit log**: `/audit last` shows recently executed commands; `/audit session` shows all in this session
 
@@ -212,7 +216,7 @@ The `run` tool can **never** be auto-accepted, even with `/autoaccept on` and pr
    ```json
    {
      "denied_command_prefixes": ["git push --force", "rm -rf"],
-     "auto_accept_safe_commands": false
+     "auto_accept_mode": "off"
    }
    ```
 2. **Use project-local skills** with `disable-model-invocation: true` for sensitive procedures

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -14,8 +14,8 @@ TinyHarness provides 15 tools across three categories. Each tool has a JSON Sche
 
 - **ReadOnly tools** run immediately in all modes
 - **Destructive tools** prompt for confirmation (Yes/No/Auto-accept for all)
-  - `run` can **never** be auto-accepted in auto-accept mode (only `write`/`edit` can)
-  - Safe commands within `run` may still auto-accept if `/autoaccept` is on and the command passes safety checks
+  - `run` can **never** be auto-accepted, even in `all` mode (only `write`/`edit` can)
+  - Safe commands within `run` may still auto-accept if `/autoaccept` is `safe` or `all` and the command passes safety checks
 - **Signal tools** are intercepted by the agent loop before reaching generic tool execution
 
 ### Mode Filtering
@@ -55,7 +55,7 @@ Reads file content with optional line ranges. For image files (png, jpg, webp, g
 
 ### `write` — Write File
 
-**Category**: Destructive | **Auto-executes**: Only in auto-accept mode
+**Category**: Destructive | **Auto-executes**: Only in `all` auto-accept mode
 
 Writes content to a file. Creates the file if it doesn't exist, overwrites if it does. Creates parent directories automatically.
 
@@ -68,7 +68,7 @@ Confirmation prompt shows the path and content preview. Use for new files or com
 
 ### `edit` — Edit File
 
-**Category**: Destructive | **Auto-executes**: Only in auto-accept mode
+**Category**: Destructive | **Auto-executes**: Only in `all` auto-accept mode
 
 Edits a file by finding an exact string and replacing it with new text. The `old_str` must appear exactly once in the file. Use for targeted changes.
 


### PR DESCRIPTION
- Add missing modules to file trees: secret.rs, debug.rs, project_settings.rs, and 5 agent submodules (command_result.rs, confirm.rs, signal.rs, tool_result.rs)
- Update /autoaccept to reflect 3-mode system (off/safe/all) across all docs (README, safety.md, configuration.md, per-project-settings.md, tools-reference.md)
- Add /debug and /autocompact slash commands to README
- Update test counts: tinyharness-lib ~89 -> ~101, total ~490 -> ~540
- Update command count 22+ -> 24+ across README and contributing.md
- Replace auto_accept_safe_commands with auto_accept_mode in all JSON examples and field descriptions
- Add auto_compact_enabled to configuration docs
- Expand CommandContext field list in TINYHARNESS.md
- Update Confirmation rule to describe off/safe/all modes