### PR TITLE
feat: showthink is now default, add show it in /settings

### DIFF
--- a/src/agent/command_result.rs
+++ b/src/agent/command_result.rs
@@ -138,6 +138,7 @@ pub fn apply_skill_use(
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             });
             session.append_message(messages.last().expect("just pushed a message"));
             ctx.refresh_system_prompt(messages);
@@ -178,6 +179,7 @@ pub fn apply_skill_unload(
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             });
             session.append_message(messages.last().expect("just pushed a message"));
             ctx.refresh_system_prompt(messages);

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -314,6 +314,7 @@ pub async fn run_agent_loop(
             tool_calls: vec![],
             tool_call_id: None,
             images: pending_images,
+            thinking: None,
         });
 
         // Auto-save: user message
@@ -504,6 +505,11 @@ pub async fn run_agent_loop(
                         tool_calls: vec![],
                         tool_call_id: None,
                         images: vec![],
+                        thinking: if thinking_content.is_empty() {
+                            None
+                        } else {
+                            Some(std::mem::take(&mut thinking_content))
+                        },
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
                 } else {
@@ -562,6 +568,11 @@ pub async fn run_agent_loop(
             if handle_tool_calls(
                 &tool_calls,
                 &response_content,
+                if thinking_content.is_empty() {
+                    None
+                } else {
+                    Some(&thinking_content)
+                },
                 messages,
                 &tool_manager,
                 ctx,
@@ -584,6 +595,11 @@ pub async fn run_agent_loop(
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: if thinking_content.is_empty() {
+                    None
+                } else {
+                    Some(std::mem::take(&mut thinking_content))
+                },
             });
             session.append_message(messages.last().expect("just pushed a message"));
 

--- a/src/agent/signal.rs
+++ b/src/agent/signal.rs
@@ -93,6 +93,7 @@ pub async fn handle_signal_event(
                         tool_calls: vec![],
                         tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
+            thinking: None,
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
                     SignalResult::SwitchMode {
@@ -108,6 +109,7 @@ pub async fn handle_signal_event(
                         tool_calls: vec![],
                         tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
+                        thinking: None,
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
                     SignalResult::SwitchMode {
@@ -157,6 +159,7 @@ pub async fn handle_signal_event(
                         tool_calls: vec![],
                         tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
+                        thinking: None,
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
                     SignalResult::AutoCompact {
@@ -175,6 +178,7 @@ pub async fn handle_signal_event(
                         tool_calls: vec![],
                         tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
+                        thinking: None,
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
                     SignalResult::AutoCompact {
@@ -206,6 +210,7 @@ pub async fn handle_signal_event(
                             tool_calls: vec![],
                             tool_call_id: Some(tool_call_id.to_string()),
                             images: vec![],
+            thinking: None,
                         });
                         session.append_message(messages.last().expect("just pushed a message"));
                         SignalResult::InvokeSkill {
@@ -222,6 +227,7 @@ pub async fn handle_signal_event(
                             tool_calls: vec![],
                             tool_call_id: None,
                             images: vec![],
+                            thinking: None,
                         });
                         session.append_message(messages.last().expect("just pushed a message"));
                         ctx.refresh_system_prompt(messages);
@@ -250,6 +256,7 @@ pub async fn handle_signal_event(
                         tool_calls: vec![],
                         tool_call_id: Some(tool_call_id.to_string()),
                         images: vec![],
+            thinking: None,
                     });
                     session.append_message(messages.last().expect("just pushed a message"));
                     SignalResult::InvokeSkill {
@@ -293,6 +300,7 @@ pub fn apply_question_answer(
         tool_calls: vec![],
         tool_call_id: Some(tool_call_id.to_string()),
         images: vec![],
+        thinking: None,
     });
     session.append_message(messages.last().expect("just pushed a message"));
 }
@@ -327,6 +335,7 @@ pub fn apply_question_error(
         tool_calls: vec![],
         tool_call_id: Some(tool_call_id.to_string()),
         images: vec![],
+        thinking: None,
     });
     session.append_message(messages.last().expect("just pushed a message"));
 }
@@ -347,6 +356,7 @@ pub fn apply_signal_parse_error(
         tool_calls: vec![],
         tool_call_id: Some(tool_call_id.to_string()),
         images: vec![],
+        thinking: None,
     });
     session.append_message(messages.last().expect("just pushed a message"));
 }

--- a/src/agent/tool_result.rs
+++ b/src/agent/tool_result.rs
@@ -59,6 +59,7 @@ pub fn batch_tool_results(results: Vec<GenericToolResult>) -> Vec<Message> {
                 tool_calls: vec![],
                 tool_call_id: Some(r.tool_call_id),
                 images,
+                thinking: None,
             }
         })
         .collect()

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -30,6 +30,7 @@ use super::tool_result::{
 pub async fn handle_tool_calls<W: Write>(
     tool_calls: &[ToolCall],
     response_content: &str,
+    thinking: Option<&str>,
     messages: &mut Vec<Message>,
     tool_manager: &ToolManager,
     ctx: &mut CommandContext,
@@ -66,6 +67,7 @@ pub async fn handle_tool_calls<W: Write>(
         tool_calls: tool_calls.clone(),
         tool_call_id: None,
         images: vec![],
+        thinking: thinking.map(|s| s.to_string()),
     });
     session.append_message(messages.last().expect("just pushed a message"));
 
@@ -168,6 +170,7 @@ pub async fn handle_tool_calls<W: Write>(
                 ),
                 tool_call_id: call.id.clone(),
                 tool_calls: vec![], images: vec![],
+            thinking: None,
             });
             session.append_message(messages.last().expect("just pushed a message"));
             continue;

--- a/src/agent/tui_loop.rs
+++ b/src/agent/tui_loop.rs
@@ -469,6 +469,7 @@ async fn process_user_message(
         tool_calls: vec![],
         tool_call_id: None,
         images: pending_images,
+        thinking: None,
     });
 
     // Auto-save: user message
@@ -502,6 +503,7 @@ async fn process_user_message(
         };
 
         let mut response_content = String::new();
+        let mut thinking_content = String::new();
         let mut tool_calls: Vec<tinyharness_lib::provider::ToolCall> = Vec::new();
         let mut received_done = false;
         let mut is_error = false;
@@ -548,11 +550,13 @@ async fn process_user_message(
                             // Send thinking content if present
                             if let Some(ref thinking) = msg.message.thinking
                                 && !thinking.is_empty()
-                                && ctx.show_thinking
                             {
-                                let _ = agent_event_tx.send(TuiAgentEvent::StreamingThinking(
-                                    thinking.clone(),
-                                ));
+                                thinking_content.push_str(thinking);
+                                if ctx.show_thinking {
+                                    let _ = agent_event_tx.send(TuiAgentEvent::StreamingThinking(
+                                        thinking.clone(),
+                                    ));
+                                }
                             }
 
                             // Send content chunks
@@ -589,6 +593,7 @@ async fn process_user_message(
                                 tool_calls: vec![],
                                 tool_call_id: None,
                                 images: vec![],
+                                thinking: if thinking_content.is_empty() { None } else { Some(std::mem::take(&mut thinking_content)) },
                             });
                             session.append_message(messages.last().expect("just pushed a message"));
                         } else {
@@ -647,6 +652,11 @@ async fn process_user_message(
                 tool_calls: tool_calls.clone(),
                 tool_call_id: None,
                 images: vec![],
+                thinking: if thinking_content.is_empty() {
+                    None
+                } else {
+                    Some(thinking_content.clone())
+                },
             });
             session.append_message(messages.last().expect("just pushed a message"));
 
@@ -681,6 +691,11 @@ async fn process_user_message(
             tool_calls: vec![],
             tool_call_id: None,
             images: vec![],
+            thinking: if thinking_content.is_empty() {
+                None
+            } else {
+                Some(thinking_content)
+            },
         });
         session.append_message(messages.last().expect("just pushed a message"));
         return;
@@ -910,6 +925,7 @@ async fn handle_tui_tool_calls(
                 tool_calls: vec![],
                 tool_call_id: call.id.clone(),
                 images: vec![],
+                thinking: None,
             });
             session.append_message(messages.last().expect("just pushed a message"));
             continue;

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -114,11 +114,13 @@ async fn call_llm_summarize(
                        and current task status. Do NOT add information that was not in the original conversation."
                 .to_string(),
             tool_calls: vec![], tool_call_id: None, images: vec![],
+            thinking: None,
         },
         Message {
             role: Role::User,
             content: format!("{}\n\n{}", summarization_prompt, text_to_summarize),
             tool_calls: vec![], tool_call_id: None, images: vec![],
+            thinking: None,
         },
     ];
 
@@ -392,6 +394,7 @@ fn reconstruct_messages(
             tool_calls: sys.tool_calls,
             tool_call_id: sys.tool_call_id,
             images: sys.images,
+            thinking: None,
         });
     }
 
@@ -423,6 +426,7 @@ mod tests {
             tool_calls: vec![],
             tool_call_id: None,
             images: vec![],
+            thinking: None,
         };
         let formatted = format_messages_for_summary(&[&msg]);
         assert!(formatted.contains("[USER]:"));
@@ -441,6 +445,7 @@ mod tests {
             tool_calls: vec![],
             tool_call_id: None,
             images: vec![],
+            thinking: None,
         };
         let formatted = format_messages_for_summary(&[&msg]);
         assert!(formatted.contains("[ASSISTANT]: Hello world"));
@@ -455,6 +460,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::User,
@@ -462,6 +468,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::Assistant,
@@ -469,6 +476,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::Tool,
@@ -476,6 +484,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
         ];
         let refs: Vec<&Message> = msgs.iter().collect();
@@ -521,6 +530,7 @@ mod tests {
             tool_calls: vec![],
             tool_call_id: None,
             images: vec![],
+            thinking: None,
         };
         let mut messages = vec![
             system.clone(),
@@ -530,6 +540,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::Assistant,
@@ -537,6 +548,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::User,
@@ -544,6 +556,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::Assistant,
@@ -551,6 +564,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::User,
@@ -558,6 +572,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::Assistant,
@@ -565,6 +580,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::User,
@@ -572,6 +588,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message {
                 role: Role::Assistant,
@@ -579,6 +596,7 @@ mod tests {
                 tool_calls: vec![],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
         ];
         let ctx = CompactContext {

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use tinyharness_lib::config::load_settings;
+use tinyharness_lib::config::{load_settings, save_settings};
 use tinyharness_lib::provider::{Message, Role};
 use tinyharness_ui::style::*;
 
@@ -250,6 +250,16 @@ pub fn execute(
 
         writeln!(file, "--- Message {} [{}] ---", i + 1, role_str).unwrap();
 
+        // Thinking/reasoning chain (if present) — shown before content since
+        // the model reasons before producing its answer.
+        if let Some(thinking) = &msg.thinking
+            && !thinking.is_empty()
+        {
+            writeln!(file, "[Thinking]").unwrap();
+            writeln!(file, "{}", thinking).unwrap();
+            writeln!(file).unwrap();
+        }
+
         // Content (may be very long, dump in full)
         writeln!(file, "{}", msg.content).unwrap();
 
@@ -269,6 +279,13 @@ pub fn execute(
         }
 
         writeln!(file).unwrap();
+    }
+
+    // Persist the current show_thinking state so it survives restarts.
+    let mut settings = load_settings();
+    if settings.show_thinking != ctx.show_thinking {
+        settings.show_thinking = ctx.show_thinking;
+        save_settings(&settings);
     }
 
     let _ = writeln!(
@@ -585,6 +602,7 @@ mod tests {
                 }],
                 tool_call_id: None,
                 images: vec![],
+                thinking: None,
             },
             Message::simple(Role::Tool, "file contents here"),
         ];
@@ -626,5 +644,29 @@ mod tests {
         assert!(content.contains("=== Workspace Context ==="));
         assert!(content.contains("=== Pinned Files ==="));
         assert!(content.contains("=== Skills ==="));
+    }
+
+    #[test]
+    fn test_execute_includes_thinking() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: "Here is my answer.".to_string(),
+            tool_calls: vec![],
+            tool_call_id: None,
+            images: vec![],
+            thinking: Some("Let me reason about this...".to_string()),
+        }];
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("debug-thinking.log");
+        let path_str = path.to_string_lossy().to_string();
+
+        let mut ctx = make_test_ctx();
+        let result = execute(&mut ctx, Some(&path_str), &messages);
+        assert!(result.is_ok());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("[Thinking]"));
+        assert!(content.contains("Let me reason about this..."));
     }
 }

--- a/src/commands/files.rs
+++ b/src/commands/files.rs
@@ -372,6 +372,7 @@ mod tests {
             tool_calls: vec![],
             tool_call_id: None,
             images: vec![],
+            thinking: None,
         }];
 
         inject_into_system_prompt(&mut messages, &ctx);
@@ -390,6 +391,7 @@ mod tests {
             role: Role::System,
             content: "Base prompt\n\nThe following files are pinned in context\n--- old ---\nold content\n--- End of pinned files ---".to_string(),
             tool_calls: vec![], tool_call_id: None, images: vec![],
+            thinking: None,
         }];
 
         inject_into_system_prompt(&mut messages, &ctx);

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -84,11 +84,13 @@ pub async fn execute_init(
                        the code alone: build commands, conventions, gotchas, architecture decisions. \
                        Output ONLY the raw markdown content — no code fences, no explanations before or after.".to_string(),
             tool_calls: vec![], tool_call_id: None, images: vec![],
+            thinking: None,
         },
         Message {
             role: Role::User,
             content: prompt,
             tool_calls: vec![], tool_call_id: None, images: vec![],
+            thinking: None,
         },
     ];
 

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -70,6 +70,19 @@ fn execute_summary(out: &mut Output, settings: &tinyharness_lib::config::Setting
         settings.ollama_max_retries,
     );
 
+    let _ = writeln!(
+        out,
+        "{BOLD}│{RESET} Think:     {BLUE}{}{RESET}",
+        settings.ollama_think_type,
+    );
+
+    let (st_str, st_color) = if settings.show_thinking {
+        ("on", GREEN)
+    } else {
+        ("off", ORANGE)
+    };
+    let _ = writeln!(out, "{BOLD}│{RESET} Show Think: {st_color}{st_str}{RESET}",);
+
     match settings.context_limit {
         Some(limit) => {
             let _ = writeln!(out, "{BOLD}│{RESET} Ctx Limit: {BLUE}{limit} tokens{RESET}",);

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,6 +278,7 @@ fn create_initial_session(
         tool_calls: vec![],
         tool_call_id: None,
         images: vec![],
+        thinking: None,
     }];
     (sess, msgs)
 }

--- a/tinyharness-lib/src/config/mod.rs
+++ b/tinyharness-lib/src/config/mod.rs
@@ -472,7 +472,7 @@ pub struct Settings {
     /// Controls the think/reasoning level for Ollama (default: Medium)
     #[serde(default)]
     pub ollama_think_type: OllamaThinkType,
-    /// Show the model's thinking/reasoning chain inline during streaming (default: false)
+    /// Show the model's thinking/reasoning chain inline during streaming (default: true)
     #[serde(default)]
     pub show_thinking: bool,
     /// Context limit for warning calculations only (default: None, uses model default)
@@ -530,7 +530,7 @@ impl Default for Settings {
             ollama_timeout_secs: 5,
             ollama_max_retries: 3,
             ollama_think_type: OllamaThinkType::Medium,
-            show_thinking: false,
+            show_thinking: true,
             context_limit: None,
             auto_accept_mode: AutoAcceptMode::Safe,
             skip_health_check: false,

--- a/tinyharness-lib/src/provider/mod.rs
+++ b/tinyharness-lib/src/provider/mod.rs
@@ -106,6 +106,11 @@ pub struct Message {
     /// Only meaningful for `User` role messages.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<ImageAttachment>,
+    /// Thinking/reasoning chain from the model, captured during streaming
+    /// and persisted for debugging. Not sent to the provider in API requests
+    /// (skipped in serialization for request types; only stored in sessions).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
 }
 
 impl Default for Message {
@@ -123,6 +128,7 @@ impl Message {
             tool_calls: vec![],
             tool_call_id: None,
             images: vec![],
+            thinking: None,
         }
     }
 }


### PR DESCRIPTION
Add optional  field to the Message struct to capture the model's reasoning/thinking chain alongside the response content. Populate it in the agent loop, TUI loop, signal handlers, tool results, and compact/init/files commands.

Also fix /settings summary to display the Think type and Show Thinking toggle, which were previously missing from the panel.