### PR TITLE
Add /debug --json output and clear thinking/response separation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "TinyHarness"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "clap",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "tinyharness-lib"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "futures-util",
  "glob",
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "tinyharness-ui"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "libc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "tinyharness-lib", "tinyharness-ui"]
 
 [package]
 name = "TinyHarness"
-version = "0.3.2"
+version = "0.3.3"
 license = "MIT"
 description = "tinyharness - ai coding harness"
 edition = "2024"
@@ -13,8 +13,8 @@ name = "tinyharness"
 path = "src/main.rs"
 
 [dependencies]
-tinyharness-lib = { version = "0.3.2", path = "tinyharness-lib" }
-tinyharness-ui = { version = "0.3.2", path = "tinyharness-ui" }
+tinyharness-lib = { version = "0.3.3", path = "tinyharness-lib" }
+tinyharness-ui = { version = "0.3.3", path = "tinyharness-ui" }
 clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.52.1", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 
+use serde_json::{Value, json};
 use tinyharness_lib::config::{load_settings, save_settings};
 use tinyharness_lib::provider::{Message, Role};
 use tinyharness_ui::style::*;
@@ -8,19 +9,57 @@ use crate::commands::registry::{CommandContext, CommandResult};
 
 // ── Core implementation ─────────────────────────────────────────────────────
 
+/// Parsed `/debug` arguments.
+struct DebugArgs {
+    /// Output file path (None = auto-generate).
+    path: Option<String>,
+    /// Whether to emit JSON instead of plain text.
+    json: bool,
+}
+
+/// Parse the raw argument string from `/debug`.
+///
+/// Supports:
+/// - `/debug`               → text log, auto path
+/// - `/debug --json`        → JSON, auto path
+/// - `/debug /path/to/file` → text log at path
+/// - `/debug --json /path`  → JSON at path
+/// - `/debug /path --json`  → JSON at path
+fn parse_args(arg: Option<&str>) -> DebugArgs {
+    let mut json = false;
+    let mut path: Option<String> = None;
+
+    if let Some(a) = arg
+        && !a.is_empty()
+    {
+        for part in a.split_whitespace() {
+            if part == "--json" || part == "-j" {
+                json = true;
+            } else {
+                path = Some(part.to_string());
+            }
+        }
+    }
+
+    DebugArgs { path, json }
+}
+
 pub fn execute(
     ctx: &mut CommandContext,
     arg: Option<&str>,
     messages: &[Message],
 ) -> Result<CommandResult, String> {
-    let path = match arg {
-        Some(p) if !p.is_empty() => p.to_string(),
+    let args = parse_args(arg);
+
+    let path = match &args.path {
+        Some(p) if !p.is_empty() => p.clone(),
         _ => {
             // Default: save next to the session data directory
             let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
             let dir = std::path::PathBuf::from(home).join(".local/share/tinyharness");
             let timestamp = chrono_now_or_fallback();
-            dir.join(format!("debug-{}.log", timestamp))
+            let ext = if args.json { "json" } else { "log" };
+            dir.join(format!("debug-{}.{}", timestamp, ext))
                 .to_string_lossy()
                 .to_string()
         }
@@ -39,6 +78,34 @@ pub fn execute(
     let mut file = std::fs::File::create(&file_path)
         .map_err(|e| format!("Failed to create file '{}': {}", file_path.display(), e))?;
 
+    if args.json {
+        let json_value = build_json_dump(ctx, messages);
+        let pretty = serde_json::to_string_pretty(&json_value)
+            .map_err(|e| format!("Failed to serialize JSON: {}", e))?;
+        writeln!(file, "{pretty}").unwrap();
+    } else {
+        write_text_dump(&mut file, ctx, messages);
+    }
+
+    // Persist the current show_thinking state so it survives restarts.
+    let mut settings = load_settings();
+    if settings.show_thinking != ctx.show_thinking {
+        settings.show_thinking = ctx.show_thinking;
+        save_settings(&settings);
+    }
+
+    let _ = writeln!(
+        ctx.output,
+        "{GREEN}Dumped debug info to {}{RESET}",
+        file_path.display(),
+    );
+
+    Ok(CommandResult::Ok)
+}
+
+// ── Text dump ───────────────────────────────────────────────────────────────
+
+fn write_text_dump(file: &mut std::fs::File, ctx: &CommandContext, messages: &[Message]) {
     // ── Header ────────────────────────────────────────────────────────────
     writeln!(file, "=== TinyHarness Debug Dump ===").unwrap();
     writeln!(file).unwrap();
@@ -57,34 +124,34 @@ pub fn execute(
 
     // ── Provider diagnostics ───────────────────────────────────────────────
     writeln!(file, "=== Provider Diagnostics ===").unwrap();
-    dump_provider_diagnostics(&mut file, ctx);
+    dump_provider_diagnostics(file, ctx);
     writeln!(file).unwrap();
 
     // ── Token usage ────────────────────────────────────────────────────────
     writeln!(file, "=== Token Usage ===").unwrap();
-    dump_token_usage(&mut file, ctx, messages);
+    dump_token_usage(file, ctx, messages);
     writeln!(file).unwrap();
 
     // ── Session metadata ───────────────────────────────────────────────────
     if let Some(session_id) = &ctx.session_id {
         writeln!(file, "=== Session Metadata ===").unwrap();
-        dump_session_metadata(&mut file, session_id);
+        dump_session_metadata(file, session_id);
         writeln!(file).unwrap();
     }
 
     // ── Configuration snapshot ─────────────────────────────────────────────
     writeln!(file, "=== Configuration Snapshot ===").unwrap();
-    dump_configuration_snapshot(&mut file);
+    dump_configuration_snapshot(file);
     writeln!(file).unwrap();
 
     // ── Pending images ─────────────────────────────────────────────────────
     writeln!(file, "=== Pending Images ===").unwrap();
-    dump_pending_images(&mut file, ctx);
+    dump_pending_images(file, ctx);
     writeln!(file).unwrap();
 
     // ── Command lists ──────────────────────────────────────────────────────
     writeln!(file, "=== Command Auto-Accept Lists ===").unwrap();
-    dump_command_lists(&mut file);
+    dump_command_lists(file);
     writeln!(file).unwrap();
 
     // ── System prompt source ───────────────────────────────────────────────
@@ -192,7 +259,7 @@ pub fn execute(
     }
     writeln!(file).unwrap();
 
-    // ── Skills ──────────────────────────────────────────────────────��──────
+    // ── Skills ──────────────────────────────────────────────────────────────
     writeln!(file, "=== Skills ===").unwrap();
     let all_skills = &ctx.skill_registry.skills;
     if all_skills.is_empty() {
@@ -252,16 +319,25 @@ pub fn execute(
 
         // Thinking/reasoning chain (if present) — shown before content since
         // the model reasons before producing its answer.
-        if let Some(thinking) = &msg.thinking
-            && !thinking.is_empty()
-        {
+        let has_thinking = msg.thinking.as_ref().is_some_and(|t| !t.is_empty());
+
+        if has_thinking {
             writeln!(file, "[Thinking]").unwrap();
-            writeln!(file, "{}", thinking).unwrap();
+            writeln!(file, "{}", msg.thinking.as_ref().unwrap()).unwrap();
+            writeln!(file, "[End Thinking]").unwrap();
             writeln!(file).unwrap();
         }
 
         // Content (may be very long, dump in full)
-        writeln!(file, "{}", msg.content).unwrap();
+        // Use [Response] markers when thinking was present, so the
+        // separation between reasoning and answer is unambiguous.
+        if has_thinking {
+            writeln!(file, "[Response]").unwrap();
+            writeln!(file, "{}", msg.content).unwrap();
+            writeln!(file, "[End Response]").unwrap();
+        } else {
+            writeln!(file, "{}", msg.content).unwrap();
+        }
 
         // Tool calls
         if !msg.tool_calls.is_empty() {
@@ -280,21 +356,309 @@ pub fn execute(
 
         writeln!(file).unwrap();
     }
+}
 
-    // Persist the current show_thinking state so it survives restarts.
-    let mut settings = load_settings();
-    if settings.show_thinking != ctx.show_thinking {
-        settings.show_thinking = ctx.show_thinking;
-        save_settings(&settings);
+// ── JSON dump ───────────────────────────────────────────────────────────────
+
+/// Build the complete debug dump as a structured JSON value.
+///
+/// The `thinking` and `content` fields are separate properties on each
+/// message object, giving unambiguous separation between reasoning and
+/// response without the need for text markers.
+fn build_json_dump(ctx: &CommandContext, messages: &[Message]) -> Value {
+    let settings = load_settings();
+
+    // ── Session info ───────────────────────────────────────────────────────
+    let session_info = json!({
+        "mode": ctx.current_mode,
+        "session_id": ctx.session_id,
+        "show_thinking": ctx.show_thinking,
+    });
+
+    // ── Provider diagnostics ──────────────────────────────────────────────
+    let provider_diagnostics = json!({
+        "provider_kind": settings.last_provider.to_string(),
+        "provider_url": settings.get_current_url(),
+        "current_model": settings.get_current_model(),
+        "timeout_secs": settings.ollama_timeout_secs,
+        "max_retries": settings.ollama_max_retries,
+        "think_type": settings.ollama_think_type.to_string(),
+        "api_key_configured": settings.ollama_api_key.is_some(),
+    });
+
+    // ── Token usage ────────────────────────────────────────────────────────
+    let token_usage = build_json_token_usage(ctx, messages);
+
+    // ── Session metadata ───────────────────────────────────────────────────
+    let session_metadata = ctx
+        .session_id
+        .as_ref()
+        .and_then(|id| build_json_session_metadata(id));
+
+    // ── Configuration snapshot ─────────────────────────────────────────────
+    let configuration = serde_json::to_value(&settings).unwrap_or(Value::Null);
+
+    // ── Pending images ─────────────────────────────────────────────────────
+    let pending_images: Vec<Value> = ctx
+        .pending_images
+        .iter()
+        .enumerate()
+        .map(|(i, img)| {
+            json!({
+                "index": i + 1,
+                "path": img.path.display().to_string(),
+                "size_bytes": img.size_bytes,
+                "mime_type": img.mime_type,
+            })
+        })
+        .collect();
+
+    // ── Command auto-accept lists ──────────────────────────────────────────
+    let safe: Vec<String> = settings
+        .safe_command_prefixes
+        .clone()
+        .unwrap_or_else(tinyharness_lib::config::get_default_safe_commands);
+    let denied: Vec<String> = settings.denied_command_prefixes.clone().unwrap_or_default();
+
+    let command_auto_accept = json!({
+        "auto_accept_mode": settings.auto_accept_mode.to_string(),
+        "auto_compact_enabled": settings.auto_compact_enabled,
+        "safe_command_prefixes": safe,
+        "denied_command_prefixes": denied,
+    });
+
+    // ── System prompt source ──────────────────────────────────────────────
+    let mode = ctx.current_mode;
+    let prompts_dir = &ctx.prompts_dir;
+
+    let header_source = if mode.uses_header() {
+        let header_path = prompts_dir.join("header.md");
+        match std::fs::read_to_string(&header_path) {
+            Ok(content) if !content.trim().is_empty() => json!({
+                "source": "custom_file",
+                "path": header_path.display().to_string(),
+                "bytes": content.len(),
+            }),
+            _ => json!({"source": "hardcoded_default"}),
+        }
+    } else {
+        Value::Null
+    };
+
+    let mode_path = prompts_dir.join(mode.prompts_filename());
+    let mode_prompt_source = match std::fs::read_to_string(&mode_path) {
+        Ok(content) if !content.trim().is_empty() => json!({
+            "source": "custom_file",
+            "path": mode_path.display().to_string(),
+            "bytes": content.len(),
+        }),
+        _ => json!({
+            "source": "hardcoded_default",
+            "filename": mode.prompts_filename(),
+        }),
+    };
+
+    let system_prompt = json!({
+        "header": header_source,
+        "mode_prompt": mode_prompt_source,
+        "assembled": ctx.build_system_prompt(),
+    });
+
+    // ── Workspace context ──────────────────────────────────────────────────
+    let wctx = &ctx.workspace_ctx;
+    let project_md = match &wctx.project_md {
+        Some((filename, content)) => json!({
+            "filename": filename,
+            "bytes": content.len(),
+            "content": content,
+        }),
+        None => Value::Null,
+    };
+
+    let additional_mds: Vec<Value> = wctx
+        .additional_project_mds
+        .iter()
+        .map(|(name, content)| {
+            json!({ "filename": name, "bytes": content.len(), "content": content })
+        })
+        .collect();
+
+    let workspace_context = json!({
+        "root": wctx.root.display().to_string(),
+        "project_type": wctx.project_type,
+        "project_name": wctx.project_name,
+        "is_git_repo": wctx.is_git_repo,
+        "build_command": wctx.build_command,
+        "test_command": wctx.test_command,
+        "project_md": project_md,
+        "additional_project_mds": additional_mds,
+        "formatted": wctx.format(),
+    });
+
+    // ── Pinned files ───────────────────────────────────────────────────────
+    let pinned_summaries = ctx.file_context.pinned_file_summaries();
+    let pinned_files: Vec<Value> = pinned_summaries
+        .iter()
+        .map(|(path, lines, bytes)| {
+            json!({
+                "path": path,
+                "lines": lines,
+                "bytes": bytes,
+            })
+        })
+        .collect();
+
+    // ── Skills ──────────────────────────────────────────────────────────────
+    let discovered_skills: Vec<Value> = ctx
+        .skill_registry
+        .skills
+        .iter()
+        .map(|skill| {
+            json!({
+                "name": skill.name,
+                "description": skill.description,
+                "source": skill.source,
+                "disable_model_invocation": skill.disable_model_invocation,
+                "path": skill.path.display().to_string(),
+            })
+        })
+        .collect();
+
+    let active_skills: Vec<Value> = ctx
+        .active_skills
+        .iter()
+        .filter_map(|name| {
+            ctx.skill_registry.get(name).map(|skill| {
+                json!({
+                    "name": skill.name,
+                    "description": skill.description,
+                    "source": skill.source,
+                    "path": skill.path.display().to_string(),
+                    "content": skill.content,
+                })
+            })
+        })
+        .collect();
+
+    let skills = json!({
+        "discovered": discovered_skills,
+        "active": active_skills,
+    });
+
+    // ── Messages ───────────────────────────────────────────────────────────
+    // Message already serializes with `thinking` and `content` as separate
+    // fields, so JSON gives natural separation between thinking and response.
+    let messages_json: Vec<Value> = messages
+        .iter()
+        .map(|m| {
+            let tool_calls: Vec<Value> = m
+                .tool_calls
+                .iter()
+                .map(|tc| {
+                    json!({
+                        "id": tc.id,
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    })
+                })
+                .collect();
+
+            json!({
+                "role": m.role,
+                "content": m.content,
+                "thinking": m.thinking,
+                "tool_calls": tool_calls,
+                "tool_call_id": m.tool_call_id,
+                "has_images": !m.images.is_empty(),
+                "image_count": m.images.len(),
+            })
+        })
+        .collect();
+
+    json!({
+        "version": 1,
+        "generated_at": chrono_now_or_fallback(),
+        "session_info": session_info,
+        "provider_diagnostics": provider_diagnostics,
+        "token_usage": token_usage,
+        "session_metadata": session_metadata,
+        "configuration": configuration,
+        "pending_images": pending_images,
+        "command_auto_accept": command_auto_accept,
+        "system_prompt": system_prompt,
+        "workspace_context": workspace_context,
+        "pinned_files": pinned_files,
+        "skills": skills,
+        "messages": messages_json,
+        "message_count": messages.len(),
+    })
+}
+
+fn build_json_token_usage(ctx: &CommandContext, messages: &[Message]) -> Value {
+    let last_known = ctx.compaction_token_usage.as_ref().map(|u| {
+        json!({
+            "prompt_tokens": u.prompt_tokens,
+            "completion_tokens": u.completion_tokens,
+            "total_tokens": u.total_tokens,
+        })
+    });
+
+    let (cumulative_tool_calls, cumulative_total_tokens) = if let Some(session_id) = &ctx.session_id
+    {
+        let store = tinyharness_lib::session::SessionStore::default_path();
+        store
+            .load(session_id)
+            .map(|(session, _)| {
+                let meta = session.meta();
+                (meta.total_tool_calls, meta.total_tokens_used)
+            })
+            .unwrap_or((0, 0))
+    } else {
+        (0, 0)
+    };
+
+    let total_chars: usize = messages.iter().map(|m| m.content.len()).sum();
+    let estimated_tokens = total_chars / 4;
+
+    json!({
+        "last_known": last_known,
+        "cumulative_tool_calls": cumulative_tool_calls,
+        "cumulative_total_tokens": cumulative_total_tokens,
+        "estimated_context_tokens": estimated_tokens,
+        "estimated_context_chars": total_chars,
+    })
+}
+
+fn build_json_session_metadata(session_id: &str) -> Option<Value> {
+    use tinyharness_lib::session::SessionStore;
+
+    let store = SessionStore::default_path();
+    match store.load(session_id) {
+        Ok((session, _)) => {
+            let meta = session.meta();
+            Some(json!({
+                "session_id": meta.id,
+                "working_dir": meta.working_dir,
+                "created_at": format_timestamp(meta.created_at),
+                "updated_at": format_timestamp(meta.updated_at),
+                "mode": meta.mode.to_string(),
+                "provider": meta.provider.to_string(),
+                "model": meta.model,
+                "name": meta.name,
+                "message_count": meta.message_count,
+                "token_usage": meta.token_usage.as_ref().map(|u| json!({
+                    "prompt_tokens": u.prompt_tokens,
+                    "completion_tokens": u.completion_tokens,
+                    "total_tokens": u.total_tokens,
+                })),
+                "cumulative_tool_calls": meta.total_tool_calls,
+                "cumulative_total_tokens": meta.total_tokens_used,
+            }))
+        }
+        Err(e) => Some(json!({
+            "error": e.to_string(),
+        })),
     }
-
-    let _ = writeln!(
-        ctx.output,
-        "{GREEN}Dumped debug info to {}{RESET}",
-        file_path.display(),
-    );
-
-    Ok(CommandResult::Ok)
 }
 
 // ── Diagnostic helpers ───────────────────────────────────────────────────────
@@ -667,6 +1031,199 @@ mod tests {
 
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(content.contains("[Thinking]"));
+        assert!(content.contains("[End Thinking]"));
+        assert!(content.contains("[Response]"));
+        assert!(content.contains("[End Response]"));
         assert!(content.contains("Let me reason about this..."));
+        assert!(content.contains("Here is my answer."));
+    }
+
+    #[test]
+    fn test_json_dumps_valid_json() {
+        let messages = vec![
+            Message::simple(Role::System, "You are helpful."),
+            Message::simple(Role::User, "Hello"),
+            Message::simple(Role::Assistant, "Hi there!"),
+        ];
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("debug.json");
+        let arg = format!("--json {}", path.to_string_lossy());
+
+        let mut ctx = make_test_ctx();
+        let result = execute(&mut ctx, Some(&arg), &messages);
+        assert!(result.is_ok());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: Value = serde_json::from_str(&content).expect("output must be valid JSON");
+
+        assert_eq!(parsed["version"], 1);
+        assert_eq!(parsed["message_count"], 3);
+        assert_eq!(parsed["messages"][0]["role"], "System");
+        assert_eq!(parsed["messages"][0]["content"], "You are helpful.");
+        assert_eq!(parsed["messages"][1]["role"], "User");
+        assert_eq!(parsed["messages"][2]["content"], "Hi there!");
+    }
+
+    #[test]
+    fn test_json_separates_thinking_and_response() {
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: "Here is my answer.".to_string(),
+            tool_calls: vec![],
+            tool_call_id: None,
+            images: vec![],
+            thinking: Some("Let me reason about this...".to_string()),
+        }];
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("debug-thinking.json");
+        let arg = format!("--json {}", path.to_string_lossy());
+
+        let mut ctx = make_test_ctx();
+        let result = execute(&mut ctx, Some(&arg), &messages);
+        assert!(result.is_ok());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: Value = serde_json::from_str(&content).expect("output must be valid JSON");
+
+        // thinking and content are separate JSON fields
+        assert_eq!(
+            parsed["messages"][0]["thinking"],
+            "Let me reason about this..."
+        );
+        assert_eq!(parsed["messages"][0]["content"], "Here is my answer.");
+    }
+
+    #[test]
+    fn test_json_includes_tool_calls() {
+        use tinyharness_lib::provider::ToolCall;
+
+        let messages = vec![
+            Message::simple(Role::User, "Read the file"),
+            Message {
+                role: Role::Assistant,
+                content: "I'll read that file.".to_string(),
+                tool_calls: vec![ToolCall {
+                    id: Some("call_1".to_string()),
+                    function: tinyharness_lib::provider::ToolCallFunction {
+                        name: "read".to_string(),
+                        arguments: serde_json::json!({"path": "/tmp/test.rs"}),
+                        thought_signature: None,
+                    },
+                }],
+                tool_call_id: None,
+                images: vec![],
+                thinking: None,
+            },
+            Message::simple(Role::Tool, "file contents here"),
+        ];
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("debug-tools.json");
+        let arg = format!("--json {}", path.to_string_lossy());
+
+        let mut ctx = make_test_ctx();
+        let result = execute(&mut ctx, Some(&arg), &messages);
+        assert!(result.is_ok());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: Value = serde_json::from_str(&content).expect("output must be valid JSON");
+
+        assert_eq!(parsed["messages"][1]["tool_calls"][0]["name"], "read");
+        assert_eq!(parsed["messages"][1]["tool_calls"][0]["id"], "call_1");
+    }
+
+    #[test]
+    fn test_json_includes_top_level_sections() {
+        let messages = vec![Message::simple(Role::User, "test")];
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("debug-sections.json");
+        let arg = format!("--json {}", path.to_string_lossy());
+
+        let mut ctx = make_test_ctx();
+        let result = execute(&mut ctx, Some(&arg), &messages);
+        assert!(result.is_ok());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: Value = serde_json::from_str(&content).expect("output must be valid JSON");
+
+        // All major sections should be present
+        assert!(parsed.get("session_info").is_some());
+        assert!(parsed.get("provider_diagnostics").is_some());
+        assert!(parsed.get("token_usage").is_some());
+        assert!(parsed.get("configuration").is_some());
+        assert!(parsed.get("pending_images").is_some());
+        assert!(parsed.get("command_auto_accept").is_some());
+        assert!(parsed.get("system_prompt").is_some());
+        assert!(parsed.get("workspace_context").is_some());
+        assert!(parsed.get("pinned_files").is_some());
+        assert!(parsed.get("skills").is_some());
+        assert!(parsed.get("messages").is_some());
+    }
+
+    #[test]
+    fn test_json_flag_after_path() {
+        let messages = vec![Message::simple(Role::User, "test")];
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("debug-order.json");
+        let arg = format!("{} --json", path.to_string_lossy());
+
+        let mut ctx = make_test_ctx();
+        let result = execute(&mut ctx, Some(&arg), &messages);
+        assert!(result.is_ok());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        serde_json::from_str::<Value>(&content).expect("output must be valid JSON");
+    }
+
+    #[test]
+    fn test_short_json_flag() {
+        let messages = vec![Message::simple(Role::User, "test")];
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("debug-short.json");
+        let arg = format!("-j {}", path.to_string_lossy());
+
+        let mut ctx = make_test_ctx();
+        let result = execute(&mut ctx, Some(&arg), &messages);
+        assert!(result.is_ok());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        serde_json::from_str::<Value>(&content).expect("output must be valid JSON");
+    }
+
+    #[test]
+    fn test_parse_args_defaults() {
+        let args = parse_args(None);
+        assert!(!args.json);
+        assert!(args.path.is_none());
+    }
+
+    #[test]
+    fn test_parse_args_json_only() {
+        let args = parse_args(Some("--json"));
+        assert!(args.json);
+        assert!(args.path.is_none());
+    }
+
+    #[test]
+    fn test_parse_args_path_and_json() {
+        let args = parse_args(Some("/tmp/debug.json --json"));
+        assert!(args.json);
+        assert_eq!(args.path.as_deref(), Some("/tmp/debug.json"));
+
+        let args = parse_args(Some("--json /tmp/debug.json"));
+        assert!(args.json);
+        assert_eq!(args.path.as_deref(), Some("/tmp/debug.json"));
+    }
+
+    #[test]
+    fn test_parse_args_path_only() {
+        let args = parse_args(Some("/tmp/debug.log"));
+        assert!(!args.json);
+        assert_eq!(args.path.as_deref(), Some("/tmp/debug.log"));
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -175,7 +175,7 @@ pub fn build_registry() -> CommandRegistry {
     reg.register_sync_with_usage(
         "/debug",
         "Dump the current conversation context to a log file",
-        "/debug [path]",
+        "/debug [--json] [path]",
         |arg, ctx, msg| crate::commands::debug::execute(ctx, arg, msg),
     );
 

--- a/tinyharness-lib/Cargo.toml
+++ b/tinyharness-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinyharness-lib"
-version = "0.3.2"
+version = "0.3.3"
 license = "MIT"
 description = "core liblary for tinyharness"
 edition = "2024"

--- a/tinyharness-ui/Cargo.toml
+++ b/tinyharness-ui/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "tinyharness-ui"
-version = "0.3.2"
+version = "0.3.3"
 license = "MIT"
 description = "ui library for tinyharness"
 edition = "2024"
 
 [dependencies]
-tinyharness-lib = { version = "0.3.2", path = "../tinyharness-lib" }
+tinyharness-lib = { version = "0.3.3", path = "../tinyharness-lib" }
 rustyline = { version = "18.0.0", features = ["derive"] }
 serde_json = "1.0.149"
 regex = "1.11.1"


### PR DESCRIPTION
- Add --json / -j flag to /debug command for structured JSON output
- JSON messages use separate 'thinking' and 'content' fields for unambiguous separation between reasoning and response
- Text log format now uses [End Thinking] and [Response]/[End Response] markers when thinking content is present
- JSON dump includes all existing sections: session info, provider diagnostics, token usage, configuration, workspace context, skills, etc.
- Default filename uses .json extension when --json is active
- Add 11 new tests covering JSON output, thinking separation, tool calls, flag ordering, and argument parsing
- Bump version to 0.3.3 across all workspace crates