### PR TITLE
Add questions_enabled setting and /questions command

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Switch modes with `/mode <name>`, use shortcut aliases (`/plan`, `/agent`, `/res
 | `/contextlimit [tokens]` | Show or set the context warning threshold |
 | `/autoaccept [all\|safe\|off]` | Show or set auto-accept mode (`off`, `safe` = read-only, `all` = all tools except `run`) |
 | `/autocompact [on\|off]` | Toggle the auto_compact tool (when off, the model cannot request compaction) |
+| `/questions [on\|off]` | Toggle the question tool (when off, the model cannot ask the user questions) |
 | `/showthink [on\|off]` | Toggle display of the model's thinking/reasoning chain |
 | `/timeout <seconds>` | Set Ollama request timeout (default: 5s) |
 | `/retries <count>` | Set Ollama max retries (default: 3) |

--- a/TINYHARNESS.md
+++ b/TINYHARNESS.md
@@ -23,7 +23,7 @@ Three crates in a Cargo workspace:
 ### Key `tinyharness-lib` modules
 
 - `provider/` — Provider trait, `OllamaProvider` (raw SSE, Gemini signatures), `OpenAiCompatProvider` (unified llama.cpp / vLLM / Bearer-auth hosted gateways — built on shared `OpenAiCompatInner`), `SockudoProvider` (WebSocket, ⚠️ experimental). `ToolCall` carries optional `id`, `Message` carries optional `tool_call_id`.
-- `tools/` — 15 tools (ls, read, write, edit, grep, glob, run, web_search, web_fetch, switch_mode, question, auto_compact, invoke_skill, screenshot), registration in `register_defaults()`, mode-based filtering, `register_custom_tools()` for custom tools
+- `tools/` — 15 tools (ls, read, write, edit, grep, glob, run, web_search, web_fetch, switch_mode, question, auto_compact, invoke_skill, screenshot), registration in `register_defaults()`, mode-based filtering, `ToolAvailability` (opt-out flags for `auto_compact`/`question`, both default on), `register_custom_tools()` for custom tools
 - `custom_tools/` — Custom-tool system: `CustomToolManager` (load/merge global + project `custom_tools.json`), `CustomToolDefinition`/`CustomToolCategory`, `ShellCommand` (template substitution, shell escaping, timeout, `TH_*` env vars)
 - `session.rs` — JSONL persistence, auto-save every 5 messages
 - `context.rs` — Workspace metadata + instruction file discovery (TINYHARNESS.md → .tinyharness.md → AGENTS.md → CLAUDE.md)
@@ -31,7 +31,7 @@ Three crates in a Cargo workspace:
 - `mode.rs` — Agent modes with `.md` system prompts
 - `secret.rs` — `SecretString` wrapper for API key redaction (custom `Debug` impl, serde support)
 - `sandbox.rs` — `Sandbox`: canonicalized-root path containment (lexical `..` normalization + symlink resolution), used by `--sandbox`
-- `config/mod.rs` — SettingsStore, ProviderKind (ollama/llamacpp/vllm/openai-compat/sockudo), OllamaThinkType, AutoAcceptMode (off/safe/all)
+- `config/mod.rs` — SettingsStore, ProviderKind (ollama/llamacpp/vllm/openai-compat/sockudo), OllamaThinkType, AutoAcceptMode (off/safe/all), `MergedSettings::tool_availability()`
 
 ### Binary crate structure
 
@@ -84,6 +84,7 @@ Three crates in a Cargo workspace:
 - **Confirmation**: `run` tool cannot be auto-accepted even with 'a' (auto-accept mode); only `write` and `edit` can. Auto-accept has three modes: `off`, `safe` (read-only commands), `all` (all destructive tools except `run`).
 - **Sandbox mode** (`--sandbox`, Linux only): Path-based tools (ls/read/write/edit/grep/glob) are confined to the workspace root by `ToolManager::execute_tool_call` (checked *before* execution, so it beats auto-accept). `run`'s explicit `cwd` is checked too, and in sandbox mode `run` + custom tools always need confirmation (`decide_tool_confirmation` in `src/agent/confirm.rs`, `sandbox_active` param). Sandbox state lives on `CommandContext.sandbox_active`; the system prompt gets a "Sandbox Mode" notice via `build_system_prompt`. On Windows/macOS the flag exits early with "Linux-only feature" (`cfg(target_os)` gate in `src/main.rs`).
 - **Compaction**: `/compact` uses single-pass for ≤200 intermediate messages, cascading (chunk+merge) for larger sessions.
+- **Optional tools**: `auto_compact` and `question` can each be hidden from the model via `ToolAvailability` (settings `auto_compact_enabled` / `questions_enabled`, both default `true`; global via `/autocompact` & `/questions`, or per-project via `.tinyharness/config.json`). Filtering happens in `ToolManager::tools_for_mode`, so disabled tools never reach the provider — the agent loop does not re-check at execution time.
 - **Context warnings**: Load warnings at 70%/90% thresholds based on last known token count (estimation).
 - **Session files**: JSONL (metadata line first, then message lines); malformed lines silently skipped on load; stored in `~/.local/share/tinyharness/sessions/`.
 - **Web tools**: `web_search` and `web_fetch` use `https://ollama.com/api/web_search` and require an Ollama API key set via `/apikey`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,7 @@ Settings are saved atomically: written to a `.tmp` file, then renamed. This prev
   "context_limit": null,
   "auto_accept_mode": "safe",
   "auto_compact_enabled": true,
+  "questions_enabled": true,
   "safe_command_prefixes": null,
   "denied_command_prefixes": null,
   "project_md_files": null
@@ -140,6 +141,7 @@ Can be overridden per-project via `.tinyharness/config.json` → `preferred_mode
 |-------|------|---------|-------------|
 | `auto_accept_mode` | string | `"safe"` | Auto-accept mode: `"off"`, `"safe"` (read-only commands), or `"all"` (all destructive tools except `run`). Toggle with `/autoaccept`. Legacy `auto_accept_safe_commands` (bool) and `auto_accept_all` (bool) are auto-migrated to this field. |
 | `auto_compact_enabled` | bool | `true` | Whether the `auto_compact` tool is available to the model. Toggle with `/autocompact` |
+| `questions_enabled` | bool | `true` | Whether the `question` tool is available to the model. When `false`, the model cannot stop the agent to ask the user questions. Toggle with `/questions` |
 | `safe_command_prefixes` | vec\|null | `null` | Custom safe command prefixes. If `null`, uses the hardcoded default list (43 commands). Set via `/command add/rm/reset` |
 | `denied_command_prefixes` | vec\|null | `null` | Always-denied prefixes. Takes priority over safe list. Set via `/command deny/undeny/resetdeny` |
 

--- a/docs/per-project-settings.md
+++ b/docs/per-project-settings.md
@@ -105,6 +105,28 @@ Set the default agent mode when starting a session in this project.
 
 Valid values: `casual`, `planning`, `agent`, `research`.
 
+### `questions_enabled`
+
+Controls whether the model may stop the agent to ask the user a multiple-choice
+question. Defaults to `true`; set to `false` to hide the `question` tool
+entirely (useful for unattended runs, CI, or `--prompt` one-shot mode).
+
+```json
+{
+  "questions_enabled": false
+}
+```
+
+### `auto_compact_enabled`
+
+Controls whether the model may request conversation compaction. Defaults to `true`.
+
+```json
+{
+  "auto_compact_enabled": false
+}
+```
+
 ## Viewing Merged Settings
 
 ```
@@ -121,6 +143,8 @@ Shows all effective settings with source annotations:
 │ Safe Cmds:  48 configured (default)
 │ Denied:     3 denied (project)
 │ Extra MD:   RULES.md, DEPLOYMENT.md (project)
+│ Auto-Compact: on (default)
+│ Questions:  off (project)
 ╰─────────────────────────────────────────────────╯
 
 Legend: (project) = from .tinyharness/config.json

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -169,6 +169,8 @@ Asks the user a question with predefined answer options.
 
 The agent loop presents a numbered list. User selects by number or text. The answer becomes the tool result.
 
+> This tool is enabled by default. Set `questions_enabled: false` (globally, per-project, or via `/questions off`) to hide it from the model entirely — useful for unattended or CI runs where no user is present to answer.
+
 ### `auto_compact` — Compact Conversation
 
 Requests conversation compaction to free context space.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -325,7 +325,7 @@ pub async fn run_agent_loop(
         loop {
             // Filter tools based on current mode and settings
             let (_, _, merged) = load_merged_settings();
-            let tools = tool_manager.tools_for_mode(ctx.current_mode, merged.auto_compact_enabled);
+            let tools = tool_manager.tools_for_mode(ctx.current_mode, merged.tool_availability());
 
             // Call the provider — it returns a receiver for streaming chunks
             let mut recv = {

--- a/src/commands/config_settings.rs
+++ b/src/commands/config_settings.rs
@@ -224,6 +224,45 @@ pub fn execute_autocompact(out: &mut Output, arg: Option<&str>) -> Result<Comman
     Ok(CommandResult::Ok)
 }
 
+// ── Questions (sync — no provider access needed) ─────────────────────────────
+
+/// Execute the /questions command to toggle the question tool.
+pub fn execute_questions(out: &mut Output, arg: Option<&str>) -> Result<CommandResult, String> {
+    let a = arg.unwrap_or("");
+
+    if a.is_empty() {
+        let settings = load_settings();
+        let (status, color) = if settings.questions_enabled {
+            ("on", GREEN)
+        } else {
+            ("off", ORANGE)
+        };
+        let _ = writeln!(out, "{BOLD}Questions: {color}{status}{RESET}",);
+        return Ok(CommandResult::Ok);
+    }
+
+    let new_value = match a.to_lowercase().as_str() {
+        "on" | "true" | "yes" | "1" => true,
+        "off" | "false" | "no" | "0" => false,
+        _ => {
+            return Err("Invalid value. Use 'on' or 'off', e.g. /questions off".to_string());
+        }
+    };
+
+    let mut settings = load_settings();
+    settings.questions_enabled = new_value;
+    save_settings(&settings);
+
+    let (status, color) = if new_value {
+        ("on", GREEN)
+    } else {
+        ("off", ORANGE)
+    };
+    let _ = writeln!(out, "{BOLD}Questions set to {color}{status}{RESET}",);
+
+    Ok(CommandResult::Ok)
+}
+
 // ── Think Type (async — needs provider.lock().await) ───────────────────────
 
 async_command!(
@@ -366,5 +405,21 @@ mod tests {
         let _ = execute_autocompact(&mut out, None);
         let plain = strip_ansi(&captured_string(&buf));
         assert!(plain.contains("Auto-compact:"));
+    }
+
+    #[test]
+    fn questions_invalid_value_returns_error() {
+        let (mut out, _buf) = captured_output();
+        let result = execute_questions(&mut out, Some("maybe"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid value"));
+    }
+
+    #[test]
+    fn questions_empty_shows_current() {
+        let (mut out, buf) = captured_output();
+        let _ = execute_questions(&mut out, None);
+        let plain = strip_ansi(&captured_string(&buf));
+        assert!(plain.contains("Questions:"));
     }
 }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -423,6 +423,7 @@ fn build_json_dump(ctx: &CommandContext, messages: &[Message]) -> Value {
     let command_auto_accept = json!({
         "auto_accept_mode": settings.auto_accept_mode.to_string(),
         "auto_compact_enabled": settings.auto_compact_enabled,
+        "questions_enabled": settings.questions_enabled,
         "safe_command_prefixes": safe,
         "denied_command_prefixes": denied,
     });
@@ -839,6 +840,7 @@ fn dump_command_lists(file: &mut std::fs::File) {
         settings.auto_compact_enabled
     )
     .unwrap();
+    writeln!(file, "Questions enabled: {}", settings.questions_enabled).unwrap();
     writeln!(file, "Safe command prefixes ({}):", safe.len()).unwrap();
     for cmd in &safe {
         writeln!(file, "  - {}", cmd).unwrap();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -145,6 +145,15 @@ pub fn build_registry() -> CommandRegistry {
         },
     );
 
+    reg.register_sync_with_usage(
+        "/questions",
+        "Show or toggle the question tool (on/off). When off, the model cannot ask the user questions.",
+        "/questions [on|off]",
+        |arg, ctx, _msg| {
+            crate::commands::config_settings::execute_questions(&mut ctx.output, arg)
+        },
+    );
+
     // ── Per-project settings ──────────────────────────────────────────────
 
     reg.register_sync_with_usage(
@@ -444,6 +453,7 @@ pub fn build_registry() -> CommandRegistry {
     reg.register_subcommands("/settings", vec!["all"]);
     reg.register_subcommands("/autoaccept", vec!["off", "safe", "all"]);
     reg.register_subcommands("/autocompact", vec!["off", "on"]);
+    reg.register_subcommands("/questions", vec!["off", "on"]);
     reg.register_subcommands("/apikey", vec!["clear"]);
     reg.register_subcommands("/showthink", vec!["off", "on"]);
     reg.register_subcommands("/think", vec!["high", "low", "medium", "off"]);
@@ -471,4 +481,38 @@ pub fn create_context(
     let mut ctx = CommandContext::new(provider, workspace_ctx, prompts_dir);
     ctx.show_thinking = settings.show_thinking;
     ctx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_contains_questions_command() {
+        let reg = build_registry();
+        assert!(reg.contains("/questions"));
+        assert!(reg.command_names().contains(&"/questions"));
+    }
+
+    #[test]
+    fn questions_command_has_on_off_subcommands() {
+        let reg = build_registry();
+        let binding = reg.subcommands();
+        let subs = binding.get("/questions").expect("subcommands");
+        assert!(subs.contains(&"on".to_string()));
+        assert!(subs.contains(&"off".to_string()));
+    }
+
+    #[tokio::test]
+    async fn questions_command_dispatches_without_error() {
+        let reg = build_registry();
+        let (mut ctx, _mock) = crate::test_helpers::make_context();
+        let mut messages = crate::test_helpers::make_messages("test");
+        // Empty arg only reads settings — no write to disk.
+        let result = reg
+            .dispatch("/questions", &mut ctx, &mut messages)
+            .await
+            .expect("dispatch should succeed");
+        assert!(matches!(result, CommandResult::Ok));
+    }
 }

--- a/src/commands/project_settings.rs
+++ b/src/commands/project_settings.rs
@@ -111,6 +111,15 @@ fn execute_show(out: &mut Output) {
     let (ac_str, ac_src) = format_setting(ac_val, merged.auto_compact_enabled_source, None);
     let _ = writeln!(out, "{BOLD}│{RESET} Auto-Compact: {ac_str} {ac_src}");
 
+    // ── Questions ──
+    let q_val = if merged.questions_enabled {
+        "on"
+    } else {
+        "off"
+    };
+    let (q_str, q_src) = format_setting(q_val, merged.questions_enabled_source, None);
+    let _ = writeln!(out, "{BOLD}│{RESET} Questions:  {q_str} {q_src}");
+
     let _ = writeln!(
         out,
         "{BOLD}╰─────────────────────────────────────────────────╯{RESET}",
@@ -206,7 +215,11 @@ fn execute_init(out: &mut Output) {
 
   // Enable or disable the auto_compact tool for this project.
   // When false, the model will not see auto_compact as an available tool.
-  // "auto_compact_enabled": true
+  // "auto_compact_enabled": true,
+
+  // Enable or disable the question tool for this project.
+  // When false, the model will not see question as an available tool.
+  // "questions_enabled": true
 }
 "#;
 

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -115,6 +115,13 @@ fn execute_summary(out: &mut Output, settings: &tinyharness_lib::config::Setting
         "{BOLD}│{RESET} Auto-Compact: {ac_color}{ac_str}{RESET}",
     );
 
+    let (q_str, q_color) = if settings.questions_enabled {
+        ("on", GREEN)
+    } else {
+        ("off", ORANGE)
+    };
+    let _ = writeln!(out, "{BOLD}│{RESET} Questions:  {q_color}{q_str}{RESET}",);
+
     let safe_commands = settings.get_safe_commands();
     let denied_commands = settings.get_denied_commands();
     let _ = writeln!(

--- a/tinyharness-lib/src/config/mod.rs
+++ b/tinyharness-lib/src/config/mod.rs
@@ -125,6 +125,9 @@ pub struct ProjectSettings {
     /// Override auto-compact enabled setting for this project
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_compact_enabled: Option<bool>,
+    /// Override whether the model may ask questions for this project
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub questions_enabled: Option<bool>,
 }
 
 /// Discover and load `.tinyharness/config.json` by walking up from CWD.
@@ -203,6 +206,8 @@ pub struct MergedSettings {
     pub preferred_mode_source: SettingSource,
     pub auto_compact_enabled: bool,
     pub auto_compact_enabled_source: SettingSource,
+    pub questions_enabled: bool,
+    pub questions_enabled_source: SettingSource,
 }
 
 /// Load and merge global + project settings.
@@ -250,6 +255,8 @@ fn merge_settings(global: &Settings, project: Option<&ProjectSettings>) -> Merge
             preferred_mode_source: SettingSource::Default,
             auto_compact_enabled: global.auto_compact_enabled,
             auto_compact_enabled_source: SettingSource::Default,
+            questions_enabled: global.questions_enabled,
+            questions_enabled_source: SettingSource::Default,
         },
         Some(p) => {
             // Safe commands: project extends global
@@ -304,6 +311,11 @@ fn merge_settings(global: &Settings, project: Option<&ProjectSettings>) -> Merge
                 .map(|v| (v, SettingSource::Project))
                 .unwrap_or((global.auto_compact_enabled, SettingSource::Default));
 
+            let (questions_enabled, q_source) = p
+                .questions_enabled
+                .map(|v| (v, SettingSource::Project))
+                .unwrap_or((global.questions_enabled, SettingSource::Default));
+
             MergedSettings {
                 safe_commands,
                 safe_commands_source: safe_source,
@@ -319,7 +331,19 @@ fn merge_settings(global: &Settings, project: Option<&ProjectSettings>) -> Merge
                 preferred_mode_source: mode_source,
                 auto_compact_enabled,
                 auto_compact_enabled_source: ac_source,
+                questions_enabled,
+                questions_enabled_source: q_source,
             }
+        }
+    }
+}
+
+impl MergedSettings {
+    /// Which optional tools the model is allowed to use, per merged settings.
+    pub fn tool_availability(&self) -> crate::tools::ToolAvailability {
+        crate::tools::ToolAvailability {
+            auto_compact: self.auto_compact_enabled,
+            question: self.questions_enabled,
         }
     }
 }
@@ -336,6 +360,7 @@ pub fn generate_project_config_template(settings: &Settings) -> ProjectSettings 
         project_md_files: None, // user must fill this in
         preferred_mode: Some(settings.preferred_mode),
         auto_compact_enabled: Some(settings.auto_compact_enabled),
+        questions_enabled: Some(settings.questions_enabled),
     }
 }
 
@@ -509,6 +534,12 @@ pub struct Settings {
     /// so the model cannot request conversation compaction.
     #[serde(default = "default_true")]
     pub auto_compact_enabled: bool,
+    /// Enable the question tool (default: true).
+    /// When false, the `question` tool is not advertised to the provider, so
+    /// the model cannot stop the agent to ask the user a multiple-choice
+    /// question. Toggle with `/questions`.
+    #[serde(default = "default_true")]
+    pub questions_enabled: bool,
 }
 
 fn default_true() -> bool {
@@ -538,6 +569,7 @@ impl Default for Settings {
             denied_command_prefixes: None,
             project_md_files: None,
             auto_compact_enabled: true,
+            questions_enabled: true,
         }
     }
 }
@@ -1040,6 +1072,104 @@ mod tests {
         assert_eq!(settings.last_provider, ProviderKind::Ollama);
         assert_eq!(settings.preferred_mode, AgentMode::Casual);
         assert!(!settings.skip_health_check);
+    }
+
+    #[test]
+    fn questions_enabled_defaults_to_true() {
+        let settings: Settings =
+            serde_json::from_str("{}").expect("empty object should use defaults");
+        assert!(settings.questions_enabled);
+        assert!(settings.auto_compact_enabled);
+        assert!(Settings::default().questions_enabled);
+    }
+
+    #[test]
+    fn questions_enabled_can_be_disabled_and_roundtrips() {
+        let store = SettingsStore::new(temp_settings_path());
+        let settings = Settings {
+            questions_enabled: false,
+            ..Settings::default()
+        };
+        store.save(&settings).unwrap();
+        let loaded = store.load().unwrap();
+        assert!(!loaded.questions_enabled);
+        // Other tool availability flag is independent
+        assert!(loaded.auto_compact_enabled);
+        let _ = std::fs::remove_dir_all(store.path().parent().unwrap());
+    }
+
+    #[test]
+    fn project_settings_override_questions_enabled() {
+        let global = Settings {
+            questions_enabled: true,
+            ..Settings::default()
+        };
+
+        // No project settings → global value, source = Default
+        let merged = merge_settings(&global, None);
+        assert!(merged.questions_enabled);
+        assert_eq!(merged.questions_enabled_source, SettingSource::Default);
+
+        // Project sets false → overrides global
+        let project = ProjectSettings {
+            questions_enabled: Some(false),
+            ..ProjectSettings::default()
+        };
+        let merged = merge_settings(&global, Some(&project));
+        assert!(!merged.questions_enabled);
+        assert_eq!(merged.questions_enabled_source, SettingSource::Project);
+    }
+
+    #[test]
+    fn project_settings_questions_absent_falls_back_to_global() {
+        let global = Settings {
+            questions_enabled: false,
+            ..Settings::default()
+        };
+        let project = ProjectSettings::default();
+        let merged = merge_settings(&global, Some(&project));
+        assert!(!merged.questions_enabled);
+        assert_eq!(merged.questions_enabled_source, SettingSource::Default);
+    }
+
+    #[test]
+    fn merged_settings_produce_tool_availability() {
+        let global = Settings {
+            questions_enabled: false,
+            auto_compact_enabled: true,
+            ..Settings::default()
+        };
+        let availability = merge_settings(&global, None).tool_availability();
+        assert!(!availability.question);
+        assert!(availability.auto_compact);
+
+        let global = Settings::default();
+        let availability = merge_settings(&global, None).tool_availability();
+        assert_eq!(availability, crate::tools::ToolAvailability::all());
+    }
+
+    #[test]
+    fn discover_project_settings_parses_questions_enabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(".tinyharness");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.json"), r#"{"questions_enabled": false}"#).unwrap();
+
+        let found = discover_project_settings(tmp.path()).expect("config should be discovered");
+        let settings = found.expect("config should parse");
+        assert_eq!(settings.questions_enabled, Some(false));
+        assert_eq!(settings.auto_compact_enabled, None);
+    }
+
+    #[test]
+    fn generate_project_config_template_includes_questions() {
+        let settings = Settings {
+            questions_enabled: false,
+            ..Settings::default()
+        };
+        let template = generate_project_config_template(&settings);
+        assert_eq!(template.questions_enabled, Some(false));
+        assert_eq!(template.auto_compact_enabled, Some(true));
     }
 
     #[test]

--- a/tinyharness-lib/src/tools/mod.rs
+++ b/tinyharness-lib/src/tools/mod.rs
@@ -37,6 +37,45 @@ pub enum SignalEvent {
     InvokeSkill { skill_name: String },
 }
 
+/// Controls which optional tools are advertised to the model.
+///
+/// Tools disabled here are filtered out of [`ToolManager::tools_for_mode`],
+/// so the model never sees them and cannot call them. All flags default to
+/// `true` — opt out explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolAvailability {
+    /// Whether the model may request conversation compaction (`auto_compact`).
+    pub auto_compact: bool,
+    /// Whether the model may ask the user multiple-choice questions (`question`).
+    pub question: bool,
+}
+
+impl Default for ToolAvailability {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
+impl ToolAvailability {
+    /// Every optional tool available (the default).
+    pub fn all() -> Self {
+        ToolAvailability {
+            auto_compact: true,
+            question: true,
+        }
+    }
+
+    /// Whether the named tool is available under this configuration.
+    /// Tools not listed here are always available.
+    pub fn allows(&self, tool_name: &str) -> bool {
+        match tool_name {
+            "auto_compact" => self.auto_compact,
+            "question" => self.question,
+            _ => true,
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct ToolManager {
     tools: Vec<Tool>,
@@ -117,37 +156,33 @@ impl ToolManager {
     }
 
     /// Returns the tool definitions appropriate for the given agent mode.
-    /// When `auto_compact_enabled` is false, the `auto_compact` tool is excluded.
+    ///
+    /// Tools disabled in `availability` (e.g. `auto_compact`, `question`) are
+    /// excluded, so the model never sees them.
     pub fn tools_for_mode(
         &self,
         mode: AgentMode,
-        auto_compact_enabled: bool,
+        availability: ToolAvailability,
     ) -> Vec<ToolDefinition> {
-        let filter_compact = |t: &&Tool| {
-            if t.name == "auto_compact" {
-                auto_compact_enabled
-            } else {
-                true
-            }
-        };
+        let is_available = |t: &&Tool| availability.allows(&t.name);
         match mode {
             AgentMode::Agent => self
                 .tools
                 .iter()
-                .filter(filter_compact)
+                .filter(is_available)
                 .map(|t| t.to_definition())
                 .collect(),
             AgentMode::Casual => self
                 .tools
                 .iter()
-                .filter(|t| filter_compact(t) && (t.name == "web_search" || t.name == "web_fetch"))
+                .filter(|t| is_available(t) && (t.name == "web_search" || t.name == "web_fetch"))
                 .map(|t| t.to_definition())
                 .collect(),
             AgentMode::Planning => self
                 .tools
                 .iter()
                 .filter(|t| {
-                    filter_compact(t)
+                    is_available(t)
                         && (t.category == ToolCategory::ReadOnly
                             || t.category == ToolCategory::Signal)
                 })
@@ -157,7 +192,7 @@ impl ToolManager {
                 .tools
                 .iter()
                 .filter(|t| {
-                    filter_compact(t)
+                    is_available(t)
                         && (t.category == ToolCategory::ReadOnly
                             || t.category == ToolCategory::Signal)
                 })

--- a/tinyharness-lib/tests/tool_integration.rs
+++ b/tinyharness-lib/tests/tool_integration.rs
@@ -3,7 +3,7 @@
 //! Tests the built-in tools with controlled inputs and temp directories.
 
 use tempfile::TempDir;
-use tinyharness_lib::tools::ToolManager;
+use tinyharness_lib::tools::{ToolAvailability, ToolManager};
 
 fn make_manager() -> ToolManager {
     let mut manager = ToolManager::new();
@@ -161,7 +161,10 @@ async fn tool_manager_has_all_default_tools() {
 #[tokio::test]
 async fn tools_for_agent_mode_includes_all() {
     let manager = make_manager();
-    let defs = manager.tools_for_mode(tinyharness_lib::mode::AgentMode::Agent, true);
+    let defs = manager.tools_for_mode(
+        tinyharness_lib::mode::AgentMode::Agent,
+        ToolAvailability::all(),
+    );
     let names: Vec<String> = defs.iter().map(|d| d.name.clone()).collect();
     assert!(names.contains(&"ls".to_string()));
     assert!(names.contains(&"write".to_string()));
@@ -171,7 +174,10 @@ async fn tools_for_agent_mode_includes_all() {
 #[tokio::test]
 async fn tools_for_casual_mode_limited() {
     let manager = make_manager();
-    let defs = manager.tools_for_mode(tinyharness_lib::mode::AgentMode::Casual, true);
+    let defs = manager.tools_for_mode(
+        tinyharness_lib::mode::AgentMode::Casual,
+        ToolAvailability::all(),
+    );
     let names: Vec<String> = defs.iter().map(|d| d.name.clone()).collect();
     // Casual mode only has web_search and web_fetch
     assert!(names.contains(&"web_search".to_string()));
@@ -183,11 +189,95 @@ async fn tools_for_casual_mode_limited() {
 #[tokio::test]
 async fn tools_for_planning_mode_excludes_destructive() {
     let manager = make_manager();
-    let defs = manager.tools_for_mode(tinyharness_lib::mode::AgentMode::Planning, true);
+    let defs = manager.tools_for_mode(
+        tinyharness_lib::mode::AgentMode::Planning,
+        ToolAvailability::all(),
+    );
     let names: Vec<String> = defs.iter().map(|d| d.name.clone()).collect();
     // Planning mode has read-only + signal tools
     assert!(names.contains(&"ls".to_string()));
     assert!(names.contains(&"read".to_string()));
     assert!(!names.contains(&"write".to_string()));
     assert!(!names.contains(&"run".to_string()));
+}
+
+#[tokio::test]
+async fn questions_disabled_hides_question_tool_in_every_mode() {
+    let manager = make_manager();
+    let availability = ToolAvailability {
+        question: false,
+        ..ToolAvailability::all()
+    };
+    for mode in [
+        tinyharness_lib::mode::AgentMode::Agent,
+        tinyharness_lib::mode::AgentMode::Planning,
+        tinyharness_lib::mode::AgentMode::Research,
+        tinyharness_lib::mode::AgentMode::Casual,
+    ] {
+        let defs = manager.tools_for_mode(mode, availability);
+        let names: Vec<String> = defs.iter().map(|d| d.name.clone()).collect();
+        assert!(
+            !names.contains(&"question".to_string()),
+            "{mode} still advertises `question` when disabled"
+        );
+    }
+}
+
+#[tokio::test]
+async fn questions_enabled_by_default() {
+    let manager = make_manager();
+    let defs = manager.tools_for_mode(
+        tinyharness_lib::mode::AgentMode::Agent,
+        ToolAvailability::default(),
+    );
+    let names: Vec<String> = defs.iter().map(|d| d.name.clone()).collect();
+    assert!(names.contains(&"question".to_string()));
+    assert!(names.contains(&"auto_compact".to_string()));
+}
+
+#[tokio::test]
+async fn questions_disabled_leaves_auto_compact_enabled() {
+    let manager = make_manager();
+    let availability = ToolAvailability {
+        question: false,
+        ..ToolAvailability::all()
+    };
+    let defs = manager.tools_for_mode(tinyharness_lib::mode::AgentMode::Agent, availability);
+    let names: Vec<String> = defs.iter().map(|d| d.name.clone()).collect();
+    assert!(!names.contains(&"question".to_string()));
+    assert!(names.contains(&"auto_compact".to_string()));
+    // Other signal tools are unaffected
+    assert!(names.contains(&"switch_mode".to_string()));
+    assert!(names.contains(&"invoke_skill".to_string()));
+}
+
+#[tokio::test]
+async fn both_tools_can_be_disabled_together() {
+    let manager = make_manager();
+    let availability = ToolAvailability {
+        question: false,
+        auto_compact: false,
+    };
+    let defs = manager.tools_for_mode(tinyharness_lib::mode::AgentMode::Agent, availability);
+    let names: Vec<String> = defs.iter().map(|d| d.name.clone()).collect();
+    assert!(!names.contains(&"question".to_string()));
+    assert!(!names.contains(&"auto_compact".to_string()));
+    assert!(names.contains(&"ls".to_string()));
+}
+
+#[test]
+fn tool_availability_allows_known_and_unknown_tools() {
+    let off = ToolAvailability {
+        question: false,
+        auto_compact: false,
+    };
+    assert!(!off.allows("question"));
+    assert!(!off.allows("auto_compact"));
+    // Unmanaged tools are always available
+    assert!(off.allows("ls"));
+    assert!(off.allows("some_custom_tool"));
+
+    let all = ToolAvailability::all();
+    assert!(all.allows("question"));
+    assert!(all.allows("auto_compact"));
 }


### PR DESCRIPTION
Add a boolean setting 'questions_enabled' (default: true) that controls whether the question tool is advertised to the provider. When disabled, the model never sees question as an available tool and cannot stop the agent to ask the user multiple-choice questions — useful for unattended or CI runs where nobody is present to answer.

- New /questions [on|off] slash command to toggle at runtime
- Supported in global settings and per-project config
- Shown in /settings, /project-settings, and /debug output
- Project override takes precedence over global setting

Replace the positional auto_compact_enabled bool on ToolManager::tools_for_mode with a ToolAvailability struct { auto_compact, question }, both defaulting to true, so a second optional-tool flag does not make the call site ambiguous. Filtering happens at tool-definition time, matching the existing auto_compact behaviour; the agent loop does not re-check at execution time.

Add MergedSettings::tool_availability() so the agent loop derives both flags from merged global + project settings each turn, making toggles take effect without a restart.